### PR TITLE
fix: `onLazyLoadChildren` return type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clevertask/react-sortable-tree",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "type": "module",
   "license": "MIT",
   "author": "CleverTask",

--- a/src/SortableTree/SortableTree.tsx
+++ b/src/SortableTree/SortableTree.tsx
@@ -170,6 +170,15 @@ function PrivateSortableTree({
     setOverId(over?.id ?? null);
   }, []);
 
+  const resetState = useCallback(() => {
+    setOverId(null);
+    setActiveId(null);
+    setOffsetLeft(0);
+    setCurrentPosition(null);
+
+    document.body.style.setProperty("cursor", "");
+  }, []);
+
   const handleDragEnd = useCallback(
     ({ active, over }: DragEndEvent) => {
       resetState();
@@ -191,25 +200,17 @@ function PrivateSortableTree({
         onDragEnd?.(result);
       }
     },
-    [items, projected]
+    [items, projected, onDragEnd, resetState, setItems]
   );
 
   const handleDragCancel = useCallback(() => {
     resetState();
-  }, []);
+  }, [resetState]);
 
-  const resetState = useCallback(() => {
-    setOverId(null);
-    setActiveId(null);
-    setOffsetLeft(0);
-    setCurrentPosition(null);
-
-    document.body.style.setProperty("cursor", "");
-  }, []);
 
   const handleRemove = useCallback((id: UniqueIdentifier) => {
     setItems((items) => removeItemById(items, id));
-  }, []);
+  }, [setItems]);
 
   const handleCollapse = useCallback(
     ({
@@ -231,7 +232,7 @@ function PrivateSortableTree({
         })
       );
     },
-    []
+    [onLazyLoadChildren, setItems]
   );
 
   const getMovementAnnouncement = useCallback(

--- a/src/SortableTree/types.ts
+++ b/src/SortableTree/types.ts
@@ -100,7 +100,7 @@ export interface SortableTreeProps {
   onLazyLoadChildren?: (
     id: UniqueIdentifier,
     isExpanding: boolean
-  ) => Promise<void>;
+  ) => void;
 
   /**
    * Determines if a drop indicator should be shown when dragging items.


### PR DESCRIPTION
The `onLazyLoadChildren` return type expected a resolved promise, which is incorrect. This tree list is meant not to deal with async calls. This might only be a trigger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new function to reset state after drag operations in the SortableTree component, enhancing drag-and-drop functionality.
  
- **Bug Fixes**
	- Updated the return type of the `onLazyLoadChildren` callback to improve clarity on its implementation.

- **Chores**
	- Incremented the version number of the `@clevertask/react-sortable-tree` package from `0.0.1` to `0.0.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->