### PR TITLE
chore: update version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clevertask/react-sortable-tree",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clevertask/react-sortable-tree",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clevertask/react-sortable-tree",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "license": "MIT",
   "author": "CleverTask",


### PR DESCRIPTION
This version will export the `getItemById` function