### PR TITLE
chore: remove the item map structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @clevertask/react-sortable-tree
 
-A customizable React component for rendering and managing tree structures with drag-and-drop functionality.
+A customizable React component for rendering and managing tree structures with drag-and-drop functionality. This is built on top of the [sortable tree Component from the dnd-kit library](https://github.com/clauderic/dnd-kit/blob/master/stories/3%20-%20Examples/Tree/SortableTree.tsx).
 
 ## Table of Contents
 
@@ -10,9 +10,8 @@ A customizable React component for rendering and managing tree structures with d
 - [Types](#types)
   - [TreeItem](#treeitem)
   - [TreeItems](#treeitems)
-  - [OptimizedTreeStructure](#optimizedtreestructure)
 - [Helper Functions](#helper-functions)
-  - [createOptimizedTreeStructure](#createoptimizedtreestructure)
+  - [getItemById](#getItemById)
   - [removeItemById](#removeitembyid)
   - [setTreeItemProperties](#settreeitemproperties)
 - [Roadmap](#roadmap)
@@ -29,20 +28,19 @@ npm install @clevertask/react-sortable-tree
 
 ```tsx
 import '@clevertask/react-sortable-tree/dist/style.css';
-import { SortableTree, createOptimizedTreeStructure } from '@clevertask/react-sortable-tree';
+import React, { useState } from 'react';
+import { SortableTree, TreeItems } from '@clevertask/react-sortable-tree';
 
 function App() {
-  const [treeStructure, setTreeStructure] = useState(
-    createOptimizedTreeStructure([
-      { id: '1', label: 'Item 1', children: [] },
-      { id: '2', label: 'Item 2', children: [{ id: '3', label: 'Item 2.1', children: [] }] },
-    ]),
-  );
+  const [items, setItems] = useState<TreeItems>([
+    { id: '1', label: 'Item 1', children: [] },
+    { id: '2', label: 'Item 2', children: [{ id: '3', label: 'Item 2.1', children: [] }] },
+  ]);
 
   return (
     <SortableTree
-      treeStructure={treeStructure}
-      setTreeStructure={setTreeStructure}
+      items={items}
+      setItems={setItems}
       isCollapsible
       isRemovable
       allowNestedItemAddition
@@ -56,8 +54,8 @@ function App() {
 
 | Prop                      | Type                                                            | Default     | Description                                                                                                          |
 | ------------------------- | --------------------------------------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------- |
-| `treeStructure`           | `OptimizedTreeStructure`                                        | Required    | The array of tree items to be rendered.                                                                              |
-| `setTreeStructure`        | `React.Dispatch<React.SetStateAction<OptimizedTreeStructure>>`  | Required    | Callback function called when the tree structure changes.                                                            |
+| `items`                   | `TreeItems`                                                     | Required    | The array of tree items to be rendered.                                                                              |
+| `setItems`                | `React.Dispatch<React.SetStateAction<TreeItems>>`               | Required    | Callback function called when the tree items array changes.                                                          |
 | `indentationWidth`        | `number`                                                        | `undefined` | The indentation width for children elements.                                                                         |
 | `isCollapsible`           | `boolean`                                                       | `false`     | Determines if tree items can be collapsed/expanded.                                                                  |
 | `onLazyLoadChildren`      | `(id: UniqueIdentifier, isExpanding: boolean) => Promise<void>` | `undefined` | Callback for lazy loading child items when a parent is expanded. Useful for getting child items from an API endpoint |
@@ -91,78 +89,59 @@ type TreeItem = {
 type TreeItems = TreeItem[];
 ```
 
-### OptimizedTreeStructure
-
-```typescript
-interface OptimizedTreeStructure {
-  items: TreeItems;
-  itemMap: Map<UniqueIdentifier, TreeItem>;
-}
-```
-
-The `OptimizedTreeStructure` is used internally to improve performance for large trees. Use the `createOptimizedTreeStructure` function to create this structure from a `TreeItems` array.
-
 ## Helper Functions
 
-### createOptimizedTreeStructure
+### getItemById
 
 ```typescript
-function createOptimizedTreeStructure(items: TreeItems): OptimizedTreeStructure;
+function getItemById(items: TreeItems, id: UniqueIdentifier): TreeItem | undefined;
 ```
 
-### getItemById
 Retrieves a tree item by its unique identifier.
+
+Usage example:
+
 ```typescript
-function getItemById(
-  structure: OptimizedTreeStructure,
-  id: UniqueIdentifier,
-): TreeItem | undefined;
+const item = getItemById(items, '1');
 ```
 
 ### removeItemById
 
 ```typescript
-function removeItemById(
-  structure: OptimizedTreeStructure,
-  id: UniqueIdentifier,
-): OptimizedTreeStructure;
+function removeItemById(items: TreeItems, id: UniqueIdentifier): TreeItems;
 ```
 
-This function removes an item from the tree structure by its ID. It returns a new `OptimizedTreeStructure` with the item removed from both the `items` array and the `itemMap`. It also handles removing the item from nested children.
+This function removes an item from the tree structure by its ID. It returns a new `TreeItems` array with the item removed. It also handles removing the item from nested children.
 
 Usage example:
 
 ```typescript
-const updatedStructure = removeItemById(currentStructure, '123');
-setTreeStructure(updatedStructure);
+const updatedItems = removeItemById(items, '123');
+setItems(updatedItems);
 ```
 
 ### setTreeItemProperties
 
 ```typescript
 function setTreeItemProperties(
-  structure: OptimizedTreeStructure,
+  items: TreeItems,
   id: UniqueIdentifier,
   setter: (value: TreeItem) => Partial<TreeItem>,
-): OptimizedTreeStructure;
+): TreeItems;
 ```
 
-This function updates the properties of a specific tree item. It takes a setter function that receives the current item and returns an object with the properties to be updated. It returns a new `OptimizedTreeStructure` with the updated item in both the `items` array and the `itemMap`.
+This function updates the properties of a specific tree item. It takes a setter function that receives the current item and returns an object with the properties to be updated. It returns a new `TreeItems` array with the updated item.
 
 Usage example:
 
 ```typescript
-setTreeStructure((treeStructure) => {
-  return setTreeItemProperties(treeStructure, '123', (item) => ({
+setItems((items) => {
+  return setTreeItemProperties(items, '123', (item) => ({
     label: 'New Label',
     collapsed: !item.collapsed,
   }));
 });
 ```
-
-These helper functions are designed to work with the `OptimizedTreeStructure` to ensure efficient updates to the tree. They maintain both the tree hierarchy in the `items` array and the fast lookup `O(1)` capability of the `itemMap`.
-
-Use this function to create an `OptimizedTreeStructure` from a `TreeItems` array. This is useful when initializing your state.
 
 ## Roadmap
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clevertask/react-sortable-tree",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clevertask/react-sortable-tree",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clevertask/react-sortable-tree",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "license": "MIT",
   "author": "CleverTask",

--- a/src/SortableTree/SortableTree.tsx
+++ b/src/SortableTree/SortableTree.tsx
@@ -29,7 +29,6 @@ import {
   removeItemById,
   removeChildrenOf,
   setTreeItemProperties,
-  createOptimizedTreeStructure,
 } from './utilities';
 import type {
   DropResult,
@@ -73,8 +72,8 @@ const dropAnimationConfig: DropAnimation = {
 };
 
 function PrivateSortableTree({
-  treeStructure,
-  setTreeStructure,
+  items,
+  setItems,
   isCollapsible,
   onLazyLoadChildren,
   showDropIndicator = false,
@@ -86,8 +85,6 @@ function PrivateSortableTree({
   onDragEnd,
   onItemClick,
 }: SortableTreeProps) {
-  const items = useMemo(() => treeStructure.items, [treeStructure.items]);
-
   const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
   const [overId, setOverId] = useState<UniqueIdentifier | null>(null);
   const [offsetLeft, setOffsetLeft] = useState(0);
@@ -213,11 +210,11 @@ function PrivateSortableTree({
         const newItems = buildTree(sortedItems);
         const result = findItemActualIndex(newItems, clonedItems[activeIndex].id, parentId);
 
-        setTreeStructure(createOptimizedTreeStructure(newItems));
+        setItems(newItems);
         onDragEnd?.(result);
       }
     },
-    [items, projected, onDragEnd, resetState, setTreeStructure],
+    [items, projected, onDragEnd, resetState, setItems],
   );
 
   const handleDragCancel = useCallback(() => {
@@ -226,9 +223,9 @@ function PrivateSortableTree({
 
   const handleRemove = useCallback(
     (id: UniqueIdentifier) => {
-      setTreeStructure((items) => removeItemById(items, id));
+      setItems((items) => removeItemById(items, id));
     },
-    [setTreeStructure],
+    [setItems],
   );
 
   const handleCollapse = useCallback(
@@ -245,13 +242,13 @@ function PrivateSortableTree({
         return onLazyLoadChildren?.(id, Boolean(collapsed));
       }
 
-      return setTreeStructure((items) =>
+      return setItems((items) =>
         setTreeItemProperties(items, id, (item) => {
           return { collapsed: !item.collapsed };
         }),
       );
     },
-    [onLazyLoadChildren, setTreeStructure],
+    [onLazyLoadChildren, setItems],
   );
 
   const getMovementAnnouncement = useCallback(
@@ -375,7 +372,7 @@ function PrivateSortableTree({
                 id={activeId}
                 depth={activeItem.depth}
                 clone
-                childCount={getChildCount(treeStructure, activeId) + 1}
+                childCount={getChildCount(items, activeId) + 1}
                 value={activeItem.label}
                 indentationWidth={indentationWidth}
               />

--- a/src/SortableTree/index.ts
+++ b/src/SortableTree/index.ts
@@ -1,8 +1,3 @@
 export * from './types';
 export { SortableTree } from './SortableTree';
-export {
-  setTreeItemProperties,
-  removeItemById,
-  createOptimizedTreeStructure,
-  getItemById,
-} from './utilities';
+export { setTreeItemProperties, removeItemById, getItemById } from './utilities';

--- a/src/SortableTree/types.ts
+++ b/src/SortableTree/types.ts
@@ -1,11 +1,6 @@
 import type { MutableRefObject } from 'react';
 import type { UniqueIdentifier } from '@dnd-kit/core';
 
-export interface OptimizedTreeStructure {
-  items: TreeItems;
-  itemMap: Map<UniqueIdentifier, TreeItem>;
-}
-
 /**
  * Represents an item in the tree structure.
  */
@@ -77,13 +72,13 @@ export interface SortableTreeProps {
   /**
    * The array of tree items to be rendered.
    */
-  treeStructure: OptimizedTreeStructure;
+  items: TreeItems;
 
   /**
    * Callback function called when the tree structure changes.
    * @param items - The updated array of tree items.
    */
-  setTreeStructure: React.Dispatch<React.SetStateAction<OptimizedTreeStructure>>;
+  setItems: React.Dispatch<React.SetStateAction<TreeItems>>;
 
   /**
    * Determines if tree items can be collapsed/expanded.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,23 +1,27 @@
-import { StrictMode, useState } from 'react';
+import { StrictMode, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { createOptimizedTreeStructure, SortableTree } from './index';
+import { getItemById, SortableTree, TreeItems } from './index';
 
 const App = () => {
-  const [treeStructure, setTreeStructure] = useState(
-    createOptimizedTreeStructure([
-      { id: '1', label: 'Hello', children: [] },
-      {
-        id: '2',
-        label: 'World',
-        children: [{ id: '2.2', label: 'Hello world!', children: [] }],
-      },
-    ]),
-  );
+  const [treeItems, setTreeItems] = useState<TreeItems>([
+    { id: '1', label: 'Hello', children: [] },
+    {
+      id: '2',
+      label: 'World',
+      children: [
+        { id: '2.2', label: 'Hello world!', children: [{ id: '2.2.2', label: 'a', children: [] }] },
+      ],
+    },
+  ]);
+
+  useEffect(() => {
+    console.log(getItemById(treeItems, '2'));
+  }, [treeItems]);
 
   return (
     <SortableTree
-      treeStructure={treeStructure}
-      setTreeStructure={setTreeStructure}
+      items={treeItems}
+      setItems={setTreeItems}
       isRemovable
       allowNestedItemAddition
       showDropIndicator


### PR DESCRIPTION
The `itemMap` was an efficient lookup table for items by their IDs, providing `O(1)` access time whenever we wanted to edit or remove an item from the tree list. This was particularly beneficial when:

- **The entire tree data is loaded upfront:** When all data is available, `itemMap` allows quick access without traversing the tree.
- **Frequent lookups are necessary:** Applications requiring constant access to items by ID benefit from this efficiency.
- **Performance is critical:** In large datasets, traversing the items array can become costly; itemMap mitigates this.

However, with asynchronous data loading, where items are fetched on demand (by using the `onLazyLoadChildren` prop):
- **Inconsistencies may arise:** The `itemMap` may not always reflect the latest state, leading to stale data issues.
- **Complexity increases:** Managing synchronization between the `itemMap` and the aree structure becomes more challenging.
- **Limited benefit:** The advantages of `itemMap` diminish if not all items are present, as the map would not contain unloaded items.

Most of the time, we want to load the data asynchronously so as not to load data unnecessarily on the tree list. To improve performance, `virtualization` should mitigate performance issues when the tree list is extensive. That might be implemented in a future PR