### PR TITLE
chore: use OIDC for publishing the package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,4 +34,4 @@ jobs:
         run: pnpm build
 
       - name: Publish lib
-        run: npm publish
+        run: pnpm publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,19 @@
-name: Publish to npm
+name: Publish Package
 
 on:
+  workflow_dispatch:
   release:
     types: [created]
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -27,5 +35,3 @@ jobs:
 
       - name: Publish lib
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR adapts the publish file to upload the package using [OIDC](https://docs.npmjs.com/trusted-publishers) to stick to the [latest way](https://docs.npmjs.com/trusted-publishers) for publishing packages in npm