### PR TITLE
Flatten tree structure data structure for the `item` property

### DIFF
--- a/src/SortableTree/SortableTree.tsx
+++ b/src/SortableTree/SortableTree.tsx
@@ -23,6 +23,7 @@ import { SortableContext, arrayMove, verticalListSortingStrategy } from '@dnd-ki
 
 import {
   buildTree,
+  convertTreeToFlatItems,
   flattenTree,
   getProjection,
   getChildCount,
@@ -33,6 +34,7 @@ import {
 import type {
   DropResult,
   FlattenedItem,
+  FlatTreeItems,
   SensorContext,
   SortableTreeProps,
   TreeItem,
@@ -71,6 +73,12 @@ const dropAnimationConfig: DropAnimation = {
   },
 };
 
+function buildTreeFromFlatItems<T extends TreeItem = TreeItem>(
+  items: FlatTreeItems<T>,
+): TreeItems<T> {
+  return buildTree(items as unknown as FlattenedItem[]);
+}
+
 function PrivateSortableTree<T extends TreeItem = TreeItem>({
   items,
   setItems,
@@ -94,8 +102,16 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
     overId: UniqueIdentifier;
   } | null>(null);
 
+  const treeItems = useMemo<TreeItems<T>>(() => {
+    return buildTreeFromFlatItems(items);
+  }, [items]);
+
+  const flatItems = useMemo(() => {
+    return flattenTree(treeItems);
+  }, [treeItems]);
+
   const flattenedItems = useMemo(() => {
-    let flattenedTree = flattenTree(items);
+    let flattenedTree = flatItems;
 
     // Disable dragging capabilities if there's just one item at root level
     const rootItems = flattenedTree.filter(({ parentId }) => !parentId);
@@ -124,7 +140,7 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
       flattenedTree,
       activeId ? [activeId, ...collapsedItems] : collapsedItems,
     );
-  }, [activeId, items]);
+  }, [activeId, flatItems]);
 
   const projected =
     activeId && overId ?
@@ -150,6 +166,17 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
   const sortedIds = useMemo(() => flattenedItems.map(({ id }) => id), [flattenedItems]);
 
   const activeItem = activeId ? flattenedItems.find(({ id }) => id === activeId) : null;
+
+  const setTreeItems = useCallback(
+    (nextItems: TreeItems<T> | ((items: TreeItems<T>) => TreeItems<T>)) => {
+      setItems((prevItems) => {
+        const previousTree = buildTreeFromFlatItems(prevItems);
+        const resolvedItems = typeof nextItems === 'function' ? nextItems(previousTree) : nextItems;
+        return convertTreeToFlatItems(resolvedItems);
+      });
+    },
+    [setItems],
+  );
 
   useEffect(() => {
     sensorContext.current = {
@@ -200,7 +227,7 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
 
       if (projected && over) {
         const { depth, parentId } = projected;
-        const clonedItems: FlattenedItem[] = JSON.parse(JSON.stringify(flattenTree(items)));
+        const clonedItems: FlattenedItem[] = JSON.parse(JSON.stringify(flatItems));
         const overIndex = clonedItems.findIndex(({ id }) => id === over.id);
         const activeIndex = clonedItems.findIndex(({ id }) => id === active.id);
         const activeTreeItem = clonedItems[activeIndex];
@@ -211,11 +238,11 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
         const newItems = buildTree(sortedItems);
         const result = findItemActualIndex(newItems, clonedItems[activeIndex].id, parentId);
 
-        setItems(newItems as TreeItems<T>);
+        setTreeItems(newItems as TreeItems<T>);
         onDragEnd?.(result);
       }
     },
-    [items, projected, onDragEnd, resetState, setItems],
+    [flatItems, projected, onDragEnd, resetState, setTreeItems],
   );
 
   const handleDragCancel = useCallback(() => {
@@ -224,9 +251,9 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
 
   const handleRemove = useCallback(
     (id: UniqueIdentifier) => {
-      setItems((items) => removeItemById(items, id));
+      setTreeItems((items) => removeItemById(items, id));
     },
-    [setItems],
+    [setTreeItems],
   );
 
   const handleCollapse = useCallback(
@@ -243,13 +270,13 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
         return onLazyLoadChildren?.(id, Boolean(collapsed));
       }
 
-      return setItems((items) =>
+      return setTreeItems((items) =>
         setTreeItemProperties(items, id, (item) => {
           return { collapsed: !item.collapsed } as T;
         }),
       );
     },
-    [onLazyLoadChildren, setItems],
+    [onLazyLoadChildren, setTreeItems],
   );
 
   const getMovementAnnouncement = useCallback(
@@ -270,7 +297,7 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
           }
         }
 
-        const clonedItems: FlattenedItem[] = JSON.parse(JSON.stringify(flattenTree(items)));
+        const clonedItems: FlattenedItem[] = JSON.parse(JSON.stringify(flatItems));
         const overIndex = clonedItems.findIndex(({ id }) => id === overId);
         const activeIndex = clonedItems.findIndex(({ id }) => id === activeId);
         const sortedItems = arrayMove(clonedItems, activeIndex, overIndex);
@@ -305,7 +332,7 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
 
       return;
     },
-    [currentPosition, items, projected],
+    [currentPosition, flatItems, projected],
   );
 
   const announcements: Announcements = {
@@ -378,7 +405,7 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
                   id={activeId}
                   depth={activeItem.depth}
                   clone
-                  childCount={getChildCount(items, activeId) + 1}
+                  childCount={getChildCount(treeItems, activeId) + 1}
                   value={activeItem}
                   indentationWidth={indentationWidth}
                   renderItem={renderItem}

--- a/src/SortableTree/SortableTree.tsx
+++ b/src/SortableTree/SortableTree.tsx
@@ -22,11 +22,10 @@ import {
 import { SortableContext, arrayMove, verticalListSortingStrategy } from '@dnd-kit/sortable';
 
 import {
-  buildTree,
-  convertTreeToFlatItems,
-  flattenTree,
+  buildFlattenedItems,
   getProjection,
   getChildCount,
+  getChildrenCountById,
   removeItemById,
   removeChildrenOf,
   setTreeItemProperties,
@@ -34,7 +33,6 @@ import {
 import type {
   DropResult,
   FlattenedItem,
-  FlatTreeItems,
   SensorContext,
   SortableTreeProps,
   TreeItem,
@@ -73,12 +71,6 @@ const dropAnimationConfig: DropAnimation = {
   },
 };
 
-function buildTreeFromFlatItems<T extends TreeItem = TreeItem>(
-  items: FlatTreeItems<T>,
-): TreeItems<T> {
-  return buildTree(items as unknown as FlattenedItem[]);
-}
-
 function PrivateSortableTree<T extends TreeItem = TreeItem>({
   items,
   setItems,
@@ -102,19 +94,19 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
     overId: UniqueIdentifier;
   } | null>(null);
 
-  const treeItems = useMemo<TreeItems<T>>(() => {
-    return buildTreeFromFlatItems(items);
+  const flatItems = useMemo(() => {
+    return buildFlattenedItems(items);
   }, [items]);
 
-  const flatItems = useMemo(() => {
-    return flattenTree(treeItems);
-  }, [treeItems]);
+  const childrenCountById = useMemo(() => {
+    return getChildrenCountById(items);
+  }, [items]);
 
   const flattenedItems = useMemo(() => {
     let flattenedTree = flatItems;
 
     // Disable dragging capabilities if there's just one item at root level
-    const rootItems = flattenedTree.filter(({ parentId }) => !parentId);
+    const rootItems = flattenedTree.filter(({ parentId }) => parentId == null);
     if (rootItems.length === 1) {
       flattenedTree = flattenedTree.map((item) =>
         item.id === rootItems[0].id ?
@@ -126,21 +118,19 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
       );
     }
 
-    const collapsedItems = flattenedTree.reduce<UniqueIdentifier[]>(
-      (acc, { children, collapsed, id }) => {
-        if (collapsed && children.length) {
-          acc.push(id);
-        }
-        return acc;
-      },
-      [],
-    );
+    const collapsedItems = flattenedTree.reduce<UniqueIdentifier[]>((acc, { collapsed, id }) => {
+      const hasChildren = (childrenCountById.get(id) ?? 0) > 0;
+      if (collapsed && hasChildren) {
+        acc.push(id);
+      }
+      return acc;
+    }, []);
 
     return removeChildrenOf(
       flattenedTree,
       activeId ? [activeId, ...collapsedItems] : collapsedItems,
     );
-  }, [activeId, flatItems]);
+  }, [activeId, childrenCountById, flatItems]);
 
   const projected =
     activeId && overId ?
@@ -169,11 +159,7 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
 
   const setTreeItems = useCallback(
     (nextItems: TreeItems<T> | ((items: TreeItems<T>) => TreeItems<T>)) => {
-      setItems((prevItems) => {
-        const previousTree = buildTreeFromFlatItems(prevItems);
-        const resolvedItems = typeof nextItems === 'function' ? nextItems(previousTree) : nextItems;
-        return convertTreeToFlatItems(resolvedItems);
-      });
+      setItems((prevItems) => (typeof nextItems === 'function' ? nextItems(prevItems) : nextItems));
     },
     [setItems],
   );
@@ -235,10 +221,11 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
         clonedItems[activeIndex] = { ...activeTreeItem, depth, parentId };
 
         const sortedItems = arrayMove(clonedItems, activeIndex, overIndex);
-        const newItems = buildTree(sortedItems);
-        const result = findItemActualIndex(newItems, clonedItems[activeIndex].id, parentId);
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const newItems = sortedItems.map(({ depth, index, ...rest }) => rest) as TreeItems<T>;
+        const result = findItemActualIndex(newItems, clonedItems[activeIndex].id);
 
-        setTreeItems(newItems as TreeItems<T>);
+        setTreeItems(newItems);
         onDragEnd?.(result);
       }
     },
@@ -368,7 +355,10 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
       >
         <SortableContext items={sortedIds} strategy={verticalListSortingStrategy}>
           {flattenedItems.map((item) => {
-            const { id, children, collapsed, depth, canFetchChildren, disableDragging } = item;
+            const { id, collapsed, depth, canFetchChildren, disableDragging } = item;
+            const hasChildren = (childrenCountById.get(id) ?? 0) > 0;
+            const canCollapse = hasChildren || Boolean(canFetchChildren);
+
             return (
               <SortableTreeItem
                 key={id}
@@ -378,9 +368,9 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
                 depth={id === activeId && projected ? projected.depth : depth}
                 indentationWidth={indentationWidth}
                 indicator={showDropIndicator}
-                collapsed={Boolean(collapsed && (children.length || canFetchChildren))}
+                collapsed={Boolean(collapsed && canCollapse)}
                 onCollapse={
-                  isCollapsible && (children.length || canFetchChildren) ?
+                  isCollapsible && canCollapse ?
                     () => handleCollapse({ id, canFetchChildren, collapsed })
                   : undefined
                 }
@@ -405,7 +395,7 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
                   id={activeId}
                   depth={activeItem.depth}
                   clone
-                  childCount={getChildCount(treeItems, activeId) + 1}
+                  childCount={getChildCount(items, activeId) + 1}
                   value={activeItem}
                   indentationWidth={indentationWidth}
                   renderItem={renderItem}
@@ -427,24 +417,32 @@ const adjustTranslate: Modifier = ({ transform }) => {
   };
 };
 
-function findItemActualIndex(
-  items: TreeItems,
-  targetId: UniqueIdentifier,
-  parent: UniqueIdentifier | null = null,
-): DropResult | null {
-  for (let i = 0; i < items.length; i++) {
-    const item = items[i];
-    if (item.id === targetId) {
-      return { index: i, parent, movedItem: item };
-    }
-    if (item.children && item.children.length > 0) {
-      const result = findItemActualIndex(item.children, targetId, item.id);
-      if (result) {
-        return result;
+function findItemActualIndex(items: TreeItems, targetId: UniqueIdentifier): DropResult | null {
+  const targetItem = items.find((item) => item.id === targetId);
+
+  if (!targetItem) {
+    return null;
+  }
+
+  const parentId = targetItem.parentId ?? null;
+  let index = -1;
+  let siblingIndex = 0;
+
+  for (const item of items) {
+    if (item.parentId === parentId) {
+      if (item.id === targetId) {
+        index = siblingIndex;
+        break;
       }
+      siblingIndex += 1;
     }
   }
-  return null;
+
+  if (index === -1) {
+    return null;
+  }
+
+  return { index, parent: parentId, movedItem: targetItem };
 }
 
 export const SortableTree = <T extends TreeItem = TreeItem>(props: SortableTreeProps<T>) => {

--- a/src/SortableTree/components/TreeItemStructure/index.tsx
+++ b/src/SortableTree/components/TreeItemStructure/index.tsx
@@ -1,4 +1,4 @@
-import { TreeItem } from '../../types';
+import { TreeItem, UniqueIdentifier } from '../../types';
 import { RenderItemProps } from '../TreeItem/TreeItem';
 import React, { createContext } from 'react';
 
@@ -9,7 +9,7 @@ type AriaProps = {
 };
 
 export type TreeItemStructureProps = {
-  treeItem: TreeItem & { parentId?: string };
+  treeItem: TreeItem & { parentId?: UniqueIdentifier | null };
   dropZoneRef: (element: HTMLElement | null) => void;
   draggableItemRef: React.Ref<any>;
   dropZoneStyle?: React.CSSProperties;

--- a/src/SortableTree/index.ts
+++ b/src/SortableTree/index.ts
@@ -2,5 +2,10 @@ export * from './types';
 export { SortableTree } from './SortableTree';
 export { TreeItemStructure } from './components';
 export type { TreeItemStructureProps, RenderItemProps } from './components';
-export { setTreeItemProperties, removeItemById, getItemById } from './utilities';
+export {
+  setTreeItemProperties,
+  removeItemById,
+  getItemById,
+  convertTreeToFlatItems,
+} from './utilities';
 export { createSortableTreeGlobalStyles } from './createSortableTreeGlobalStyles';

--- a/src/SortableTree/types.ts
+++ b/src/SortableTree/types.ts
@@ -47,6 +47,28 @@ export type BaseTreeItem<ExtraProps = unknown> = {
 
 export type TreeItems<ExtraProps = unknown> = TreeItem<ExtraProps>[];
 
+/**
+ * Represents a flattened tree item that references its parent instead of nesting.
+ */
+export type FlatTreeItem<ExtraProps = unknown> = Omit<TreeItem<ExtraProps>, 'children'> & {
+  /**
+   * The parent id for this item. Use null for root items.
+   */
+  parentId: UniqueIdentifier | null;
+
+  /**
+   * Optional metadata for consumers who already track depth.
+   */
+  depth?: number;
+
+  /**
+   * Optional metadata for consumers who already track index.
+   */
+  index?: number;
+};
+
+export type FlatTreeItems<ExtraProps = unknown> = FlatTreeItem<ExtraProps>[];
+
 export interface FlattenedItem extends TreeItem {
   parentId: UniqueIdentifier | null;
   depth: number;
@@ -68,15 +90,15 @@ export interface SortableTreeProps<T extends TreeItem = TreeItem> {
   indentationWidth?: number;
 
   /**
-   * The array of tree items to be rendered.
+   * The flat array of items to be rendered.
    */
-  items: TreeItems<T>;
+  items: FlatTreeItems<T>;
 
   /**
    * Callback function called when the tree structure changes.
-   * @param items - The updated array of tree items.
+   * @param items - The updated flat array of tree items.
    */
-  setItems: React.Dispatch<React.SetStateAction<TreeItems<T>>>;
+  setItems: React.Dispatch<React.SetStateAction<FlatTreeItems<T>>>;
 
   /**
    * Determines if tree items can be collapsed/expanded.

--- a/src/SortableTree/types.ts
+++ b/src/SortableTree/types.ts
@@ -2,12 +2,10 @@ import type { MutableRefObject } from 'react';
 import type { UniqueIdentifier } from '@dnd-kit/core';
 import { Props } from './components/TreeItem/TreeItem';
 
-export type TreeItem<ExtraProps = unknown> = BaseTreeItem & ExtraProps;
-
 /**
- * Represents an item in the tree structure.
+ * Represents a flat item in the tree structure.
  */
-export type BaseTreeItem<ExtraProps = unknown> = {
+export type BaseTreeItem = {
   /**
    * Unique identifier for the item. Can be a string or number.
    */
@@ -19,9 +17,9 @@ export type BaseTreeItem<ExtraProps = unknown> = {
   label: string;
 
   /**
-   * An array of child TreeItems. If empty, the item is a leaf node.
+   * The parent id for this item. Use null for root items.
    */
-  children: TreeItem<ExtraProps>[];
+  parentId: UniqueIdentifier | null;
 
   /**
    * Determines whether the item's children are initially collapsed.
@@ -45,35 +43,30 @@ export type BaseTreeItem<ExtraProps = unknown> = {
   disableDragging?: boolean;
 };
 
+export type TreeItem<ExtraProps = unknown> = BaseTreeItem & ExtraProps;
 export type TreeItems<ExtraProps = unknown> = TreeItem<ExtraProps>[];
 
 /**
- * Represents a flattened tree item that references its parent instead of nesting.
+ * Represents a nested item (legacy or internal) that includes children.
  */
-export type FlatTreeItem<ExtraProps = unknown> = Omit<TreeItem<ExtraProps>, 'children'> & {
+export type TreeItemWithChildren<ExtraProps = unknown> = Omit<TreeItem<ExtraProps>, 'parentId'> & {
   /**
-   * The parent id for this item. Use null for root items.
+   * The parent id for this item. Legacy items may omit it.
    */
-  parentId: UniqueIdentifier | null;
+  parentId?: UniqueIdentifier | null;
 
   /**
-   * Optional metadata for consumers who already track depth.
+   * An array of child items. If empty, the item is a leaf node.
    */
-  depth?: number;
-
-  /**
-   * Optional metadata for consumers who already track index.
-   */
-  index?: number;
+  children: TreeItemWithChildren<ExtraProps>[];
 };
 
-export type FlatTreeItems<ExtraProps = unknown> = FlatTreeItem<ExtraProps>[];
+export type TreeItemsWithChildren<ExtraProps = unknown> = TreeItemWithChildren<ExtraProps>[];
 
-export interface FlattenedItem extends TreeItem {
-  parentId: UniqueIdentifier | null;
+export type FlattenedItem<ExtraProps = unknown> = {
   depth: number;
   index: number;
-}
+} & TreeItem<ExtraProps>;
 
 export type SensorContext = MutableRefObject<{
   items: FlattenedItem[];
@@ -92,13 +85,13 @@ export interface SortableTreeProps<T extends TreeItem = TreeItem> {
   /**
    * The flat array of items to be rendered.
    */
-  items: FlatTreeItems<T>;
+  items: TreeItems<T>;
 
   /**
    * Callback function called when the tree structure changes.
    * @param items - The updated flat array of tree items.
    */
-  setItems: React.Dispatch<React.SetStateAction<FlatTreeItems<T>>>;
+  setItems: React.Dispatch<React.SetStateAction<TreeItems<T>>>;
 
   /**
    * Determines if tree items can be collapsed/expanded.

--- a/src/SortableTree/utilities.ts
+++ b/src/SortableTree/utilities.ts
@@ -1,7 +1,7 @@
 import type { UniqueIdentifier } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
 
-import type { FlatTreeItems, FlattenedItem, TreeItem, TreeItems } from './types';
+import type { FlattenedItem, TreeItem, TreeItems, TreeItemsWithChildren } from './types';
 
 export const iOS = /iPad|iPhone|iPod/.test(navigator.platform);
 
@@ -76,66 +76,143 @@ function getMinDepth({ nextItem }: { nextItem: FlattenedItem }) {
   return 0;
 }
 
-function flatten(
-  items: TreeItems,
+type ParentId = UniqueIdentifier | null;
+
+function buildChildrenByParentId<T extends TreeItem>(items: TreeItems<T>) {
+  const itemsById = new Map<UniqueIdentifier, T>();
+
+  for (const item of items) {
+    itemsById.set(item.id, item);
+  }
+
+  const childrenByParentId = new Map<ParentId, T[]>();
+  const normalizedParentById = new Map<UniqueIdentifier, ParentId>();
+
+  for (const item of items) {
+    const rawParentId = item.parentId ?? null;
+    const normalizedParentId =
+      rawParentId != null && itemsById.has(rawParentId) && rawParentId !== item.id ?
+        rawParentId
+      : null;
+
+    normalizedParentById.set(item.id, normalizedParentId);
+
+    const siblings = childrenByParentId.get(normalizedParentId);
+    if (siblings) {
+      siblings.push(item);
+    } else {
+      childrenByParentId.set(normalizedParentId, [item]);
+    }
+  }
+
+  return { childrenByParentId, normalizedParentById };
+}
+
+function getDescendantIds<T extends TreeItem>(
+  items: TreeItems<T>,
+  parentIds: UniqueIdentifier[],
+): Set<UniqueIdentifier> {
+  const { childrenByParentId } = buildChildrenByParentId(items);
+  const descendants = new Set<UniqueIdentifier>();
+  const queue = [...parentIds];
+
+  while (queue.length > 0) {
+    const parentId = queue.shift();
+    if (parentId == null) {
+      continue;
+    }
+    const children = childrenByParentId.get(parentId) ?? [];
+    for (const child of children) {
+      if (descendants.has(child.id)) {
+        continue;
+      }
+      descendants.add(child.id);
+      queue.push(child.id);
+    }
+  }
+
+  return descendants;
+}
+
+export function buildFlattenedItems<T extends TreeItem>(items: TreeItems<T>): FlattenedItem<T>[] {
+  const { childrenByParentId, normalizedParentById } = buildChildrenByParentId(items);
+  const flattened: FlattenedItem<T>[] = [];
+  const visited = new Set<UniqueIdentifier>();
+
+  const visit = (parentId: ParentId, depth: number) => {
+    const children = childrenByParentId.get(parentId) ?? [];
+
+    children.forEach((item, index) => {
+      if (visited.has(item.id)) {
+        return;
+      }
+
+      visited.add(item.id);
+      const normalizedParentId = normalizedParentById.get(item.id) ?? null;
+      flattened.push({ ...item, parentId: normalizedParentId, depth, index });
+      visit(item.id, depth + 1);
+    });
+  };
+
+  visit(null, 0);
+
+  // Safety net for cyclic or disconnected graphs.
+  for (const item of items) {
+    if (visited.has(item.id)) {
+      continue;
+    }
+
+    const normalizedParentId = normalizedParentById.get(item.id) ?? null;
+    const siblings = childrenByParentId.get(normalizedParentId) ?? [];
+    const index = siblings.findIndex((sibling) => sibling.id === item.id);
+
+    flattened.push({
+      ...item,
+      parentId: normalizedParentId,
+      depth: 0,
+      index: index >= 0 ? index : 0,
+    });
+    visit(item.id, 1);
+  }
+
+  return flattened;
+}
+
+function flattenLegacyTree<T extends TreeItem>(
+  items: TreeItemsWithChildren<T>,
   parentId: UniqueIdentifier | null = null,
   depth = 0,
-): FlattenedItem[] {
-  return items.reduce<FlattenedItem[]>((acc, item, index) => {
-    acc.push({ ...item, parentId, depth, index });
-    acc.push(...flatten(item.children, item.id, depth + 1));
+): FlattenedItem<T>[] {
+  return items.reduce<FlattenedItem<T>[]>((acc, item, index) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { children, parentId: _ignoredParentId, ...rest } = item;
+    acc.push({ ...rest, parentId, depth, index });
+    acc.push(...flattenLegacyTree(children, item.id, depth + 1));
     return acc;
   }, []);
 }
 
-export function flattenTree(items: TreeItems): FlattenedItem[] {
-  return flatten(items);
+export function flattenTree<T extends TreeItem>(
+  items: TreeItemsWithChildren<T>,
+): FlattenedItem<T>[] {
+  return flattenLegacyTree(items);
 }
 
-export function convertTreeToFlatItems<T extends TreeItem>(items: TreeItems<T>): FlatTreeItems<T> {
-  return flattenTree(items).map(({ children, depth, index, ...rest }) => rest) as FlatTreeItems<T>;
-}
-
-export function buildTree(flattenedItems: FlattenedItem[]): TreeItems {
-  const root: TreeItem = { id: 'root', label: '', children: [] };
-  const nodes: Record<string, TreeItem> = { [root.id]: root };
-  const items = flattenedItems.map((item) => ({ ...item, children: [] }));
-
-  for (const item of items) {
-    const { id, children, label } = item;
-    const parentId = item.parentId ?? root.id;
-    const parent = nodes[parentId] ?? findItem(items, parentId);
-
-    nodes[id] = { id, label, children };
-    parent.children.push(item);
-  }
-
-  return root.children;
-}
-
-export function findItem(items: TreeItem[], itemId: UniqueIdentifier) {
-  return items.find(({ id }) => id === itemId);
-}
-
-export function findItemDeep(items: TreeItems, itemId: UniqueIdentifier): TreeItem | undefined {
-  const item = getItemById(items, itemId);
-  return item;
+export function convertTreeToFlatItems<T extends TreeItem>(
+  items: TreeItemsWithChildren<T>,
+): TreeItems<T> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  return flattenTree(items).map(({ depth, index, ...rest }) => rest) as TreeItems<T>;
 }
 
 export function removeItemById<T extends TreeItem>(
   items: TreeItems<T>,
   id: UniqueIdentifier,
 ): TreeItems<T> {
-  function removeFromChildren(children: TreeItems<T>): TreeItems<T> {
-    return children
-      .filter((child) => child.id !== id)
-      .map((child) => ({
-        ...child,
-        children: removeFromChildren((child.children as TreeItems<T>) || []),
-      }));
-  }
-  const newItems = removeFromChildren(items);
-  return newItems;
+  const idsToRemove = getDescendantIds(items, [id]);
+  idsToRemove.add(id);
+
+  return items.filter((item) => !idsToRemove.has(item.id));
 }
 
 export function setTreeItemProperties<T extends TreeItem>(
@@ -143,31 +220,13 @@ export function setTreeItemProperties<T extends TreeItem>(
   id: UniqueIdentifier,
   setter: (value: T) => Partial<T>,
 ): TreeItems<T> {
-  function updateItemInTree(items: TreeItems<T>): TreeItems<T> {
-    return items.map((item) => {
-      if (item.id === id) {
-        const updatedItem = { ...item, ...setter(item) };
+  return items.map((item) => {
+    if (item.id !== id) {
+      return item;
+    }
 
-        if (updatedItem.children && updatedItem.children.length > 0) {
-          updatedItem.children = updateItemInTree(updatedItem.children as TreeItems<T>);
-        }
-
-        return updatedItem;
-      } else if (item.children && item.children.length > 0) {
-        return {
-          ...item,
-          children: updateItemInTree(item.children as TreeItems<T>),
-        };
-      } else {
-        return item;
-      }
-    });
-  }
-
-  // Start the recursion with the root items
-  const newItems = updateItemInTree(items);
-
-  return newItems;
+    return { ...item, ...setter(item) };
+  });
 }
 
 /**
@@ -180,46 +239,28 @@ export function getItemById<T extends TreeItem>(
   items: TreeItems<T>,
   id: UniqueIdentifier,
 ): TreeItem<T> | undefined {
+  return items.find((item) => item.id === id);
+}
+
+export function getChildCount(items: TreeItems, id: UniqueIdentifier) {
+  return getDescendantIds(items, [id]).size;
+}
+
+export function getChildrenCountById<T extends TreeItem>(items: TreeItems<T>) {
+  const counts = new Map<UniqueIdentifier, number>();
+
   for (const item of items) {
-    if (item.id === id) {
-      return item;
-    } else if (item.children && item.children.length > 0) {
-      const foundItem = getItemById(item.children as TreeItems<T>, id);
-      if (foundItem) {
-        return foundItem;
-      }
+    const parentId = item.parentId;
+    if (parentId == null) {
+      continue;
     }
+    counts.set(parentId, (counts.get(parentId) ?? 0) + 1);
   }
-  return undefined;
-}
 
-function countChildren(items: TreeItem[], count = 0): number {
-  return items.reduce((acc, { children }) => {
-    if (children.length) {
-      return countChildren(children, acc + 1);
-    }
-
-    return acc + 1;
-  }, count);
-}
-
-export function getChildCount(treeStructure: TreeItems, id: UniqueIdentifier) {
-  const item = findItemDeep(treeStructure, id);
-
-  return item ? countChildren(item.children) : 0;
+  return counts;
 }
 
 export function removeChildrenOf(items: FlattenedItem[], ids: UniqueIdentifier[]) {
-  const excludeParentIds = [...ids];
-
-  return items.filter((item) => {
-    if (item.parentId && excludeParentIds.includes(item.parentId)) {
-      if (item.children.length) {
-        excludeParentIds.push(item.id);
-      }
-      return false;
-    }
-
-    return true;
-  });
+  const descendantIds = getDescendantIds(items, ids);
+  return items.filter((item) => !descendantIds.has(item.id));
 }

--- a/src/SortableTree/utilities.ts
+++ b/src/SortableTree/utilities.ts
@@ -1,7 +1,7 @@
 import type { UniqueIdentifier } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
 
-import type { FlattenedItem, TreeItem, TreeItems } from './types';
+import type { FlatTreeItems, FlattenedItem, TreeItem, TreeItems } from './types';
 
 export const iOS = /iPad|iPhone|iPod/.test(navigator.platform);
 
@@ -90,6 +90,10 @@ function flatten(
 
 export function flattenTree(items: TreeItems): FlattenedItem[] {
   return flatten(items);
+}
+
+export function convertTreeToFlatItems<T extends TreeItem>(items: TreeItems<T>): FlatTreeItems<T> {
+  return flattenTree(items).map(({ children, depth, index, ...rest }) => rest) as FlatTreeItems<T>;
 }
 
 export function buildTree(flattenedItems: FlattenedItem[]): TreeItems {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import {
   createSortableTreeGlobalStyles,
   SortableTree,
   TreeItem,
-  FlatTreeItems,
+  TreeItems,
   TreeItemStructure,
 } from './index';
 import { RenderItemProps } from './SortableTree/components/TreeItem/TreeItem';
@@ -13,21 +13,18 @@ import { RenderItemProps } from './SortableTree/components/TreeItem/TreeItem';
 type CustomTreeItem = TreeItem<{
   icon?: string;
   description?: string;
-  metadata?: Record<string, any>;
 }>;
-type MyTreeItem = FlatTreeItems<CustomTreeItem>;
+type MyTreeItem = TreeItems<CustomTreeItem>;
 
-const BASE_TREE = [
-  { id: 'a', label: 'A', parentId: null },
-  { id: 'b', label: 'B', parentId: null },
-  { id: 'b1', label: 'B1', parentId: 'b' },
-  { id: 'c', label: 'C', parentId: null },
-  { id: 'd', label: 'D', parentId: null },
-  { id: 'e', label: 'E', parentId: null },
-];
+// const BASE_TREE = [
+//   { id: 'a', label: 'A', parentId: null },
+//   { id: 'b', label: 'B', parentId: null },
+//   { id: 'b1', label: 'B1', parentId: 'b' },
+//   { id: 'c', label: 'C', parentId: null },
+//   { id: 'd', label: 'D', parentId: null },
+//   { id: 'e', label: 'E', parentId: null },
+// ];
 
-/*
-Legacy adapter:
 import { convertTreeToFlatItems } from './index';
 
 const LEGACY_TREE = [
@@ -43,7 +40,6 @@ const LEGACY_TREE = [
 ];
 
 const BASE_TREE = convertTreeToFlatItems(LEGACY_TREE);
-*/
 
 const App = () => {
   const [treeItems, setTreeItems] = useState<MyTreeItem>(BASE_TREE);
@@ -78,6 +74,7 @@ const App = () => {
       items={treeItems}
       setItems={setTreeItems}
       renderItem={MyCustomTreeItem}
+      onDragEnd={(r) => console.log(r)}
     />
   );
 };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,7 +5,7 @@ import {
   createSortableTreeGlobalStyles,
   SortableTree,
   TreeItem,
-  TreeItems,
+  FlatTreeItems,
   TreeItemStructure,
 } from './index';
 import { RenderItemProps } from './SortableTree/components/TreeItem/TreeItem';
@@ -15,9 +15,22 @@ type CustomTreeItem = TreeItem<{
   description?: string;
   metadata?: Record<string, any>;
 }>;
-type MyTreeItem = TreeItems<CustomTreeItem>;
+type MyTreeItem = FlatTreeItems<CustomTreeItem>;
 
 const BASE_TREE = [
+  { id: 'a', label: 'A', parentId: null },
+  { id: 'b', label: 'B', parentId: null },
+  { id: 'b1', label: 'B1', parentId: 'b' },
+  { id: 'c', label: 'C', parentId: null },
+  { id: 'd', label: 'D', parentId: null },
+  { id: 'e', label: 'E', parentId: null },
+];
+
+/*
+Legacy adapter:
+import { convertTreeToFlatItems } from './index';
+
+const LEGACY_TREE = [
   { id: 'a', label: 'A', children: [] },
   {
     id: 'b',
@@ -29,8 +42,12 @@ const BASE_TREE = [
   { id: 'e', label: 'E', children: [] },
 ];
 
+const BASE_TREE = convertTreeToFlatItems(LEGACY_TREE);
+*/
+
 const App = () => {
   const [treeItems, setTreeItems] = useState<MyTreeItem>(BASE_TREE);
+  console.log(treeItems);
 
   const MyCustomTreeItem = (props: RenderItemProps<CustomTreeItem>) => {
     const useSortableTreeGlobalStyles = createSortableTreeGlobalStyles({


### PR DESCRIPTION
This PR flattens the data structure we send to the `items` prop; thus, instead of sending the `children` [property](https://github.com/clevertask/react-sortable-tree/pull/26/changes#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811R30-R40), you'd only send the `parentId` [property](https://github.com/clevertask/react-sortable-tree/pull/26/changes#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811R19-R26) and the component will get the children by that id. So, you don't have to deal with nested arrays before sending them to the `items` property.

If you want to keep the legacy structure, you can use the helper tool:
`convertTreeToFlatItems`