### PR TITLE
Add functions to move items programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,17 @@ const [items, setItems] = useState<TreeItems<CustomTreeItem>>([
   },
 ]);
 
+// Or you can use a flat structure for your items.
+const BASE_TREE = [
+  { id: 'a', label: 'A', parentId: null },
+  { id: 'z', label: 'Z', parentId: 'a' },
+  { id: 'b', label: 'B', parentId: null },
+  { id: 'b1', label: 'B1', parentId: 'b' },
+  { id: 'c', label: 'C', parentId: null },
+  { id: 'd', label: 'D', parentId: null },
+  { id: 'e', label: 'E', parentId: null },
+];
+
 <SortableTree<CustomTreeItem>
   isCollapsible
   showDropIndicator

--- a/README.md
+++ b/README.md
@@ -302,6 +302,27 @@ export interface RenderItemProps<T extends TTreeItem = TTreeItem>
 }
 ```
 
+### DropResult
+
+```ts
+type DropResult<T extends TreeItem = TreeItem> = {
+  movedItem: T;
+  parent: UniqueIdentifier | null;
+  index: number;
+  beforeItemId?: UniqueIdentifier | null;
+  afterItemId?: UniqueIdentifier | null;
+} | null;
+```
+
+### MoveTreeItemResult
+
+```ts
+type MoveTreeItemResult<T extends TreeItem = TreeItem> = {
+  items: TreeItems<T>;
+  result: DropResult<T>;
+};
+```
+
 ---
 
 ## Helper Functions
@@ -329,6 +350,48 @@ function setTreeItemProperties<T extends TreeItem>(
   id: UniqueIdentifier,
   setter: (value: T) => Partial<T>,
 ): TreeItems<T>;
+```
+
+### getTreeItemMoveResult
+
+```ts
+function getTreeItemMoveResult<T extends TreeItem>(
+  items: TreeItems<T>,
+  targetId: UniqueIdentifier,
+): DropResult<T>;
+```
+
+### moveTreeItem
+
+```ts
+function moveTreeItem<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemId: UniqueIdentifier,
+  targetItemId: UniqueIdentifier,
+  position: 'before' | 'after' | 'inside',
+): MoveTreeItemResult<T>;
+```
+
+### moveItemBefore / moveItemAfter / moveItemInside
+
+```ts
+function moveItemBefore<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemId: UniqueIdentifier,
+  targetItemId: UniqueIdentifier,
+): MoveTreeItemResult<T>;
+
+function moveItemAfter<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemId: UniqueIdentifier,
+  targetItemId: UniqueIdentifier,
+): MoveTreeItemResult<T>;
+
+function moveItemInside<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemId: UniqueIdentifier,
+  targetItemId: UniqueIdentifier,
+): MoveTreeItemResult<T>;
 ```
 
 ---

--- a/e2e/tree.spec.ts
+++ b/e2e/tree.spec.ts
@@ -10,45 +10,45 @@ test.afterEach(async ({ page }) => {
   await page.reload();
 });
 
-test('Item A becomes a child of C after drag and drop', async ({ page }) => {
+test('Item D becomes a child of C after drag and drop', async ({ page }) => {
   await page.goto('/');
 
   await dragItem({
     page,
     expect,
-    from: { name: 'A' },
+    from: { name: 'D' },
     to: { name: 'C', position: 'inside' },
   });
 
-  await expectItemToBeChildOf(page, expect, 'A', 'C');
+  await expectItemToBeChildOf(page, expect, 'D', 'C');
 });
 
-test('Item A is moved below C after drag and drop', async ({ page }) => {
+test('Item D is moved below C after drag and drop', async ({ page }) => {
   await page.goto('/');
 
   await dragItem({
     page,
     expect,
-    from: { name: 'A' },
+    from: { name: 'D' },
     to: { name: 'C', position: 'after' },
   });
 
-  await expectItemBefore(page, expect, 'C', 'A');
-  await expectItemNotToBeChildOf(page, expect, 'A', 'C');
+  await expectItemBefore(page, expect, 'C', 'D');
+  await expectItemNotToBeChildOf(page, expect, 'D', 'C');
 });
 
-test('Item C is moved before A after drag and drop', async ({ page }) => {
+test('Item C is moved before D after drag and drop', async ({ page }) => {
   await page.goto('/');
 
   await dragItem({
     page,
     expect,
     from: { name: 'C' },
-    to: { name: 'A', position: 'before' },
+    to: { name: 'D', position: 'before' },
   });
 
-  await expectItemBefore(page, expect, 'C', 'A');
-  await expectItemNotToBeChildOf(page, expect, 'C', 'A');
+  await expectItemBefore(page, expect, 'C', 'D');
+  await expectItemNotToBeChildOf(page, expect, 'C', 'D');
 });
 
 test('Item C is moved before nested item B1 after drag and drop', async ({ page }) => {
@@ -131,17 +131,17 @@ test('Nested item B1 can be moved to top level', async ({ page }) => {
   await expectItemNotToBeChildOf(page, expect, 'B1', 'B');
 });
 
-test('Item A becomes child of B1 when dragged inside', async ({ page }) => {
+test('Item Z becomes child of B1 when dragged inside', async ({ page }) => {
   await page.goto('/');
 
   await dragItem({
     page,
     expect,
-    from: { name: 'A' },
+    from: { name: 'Z' },
     to: { name: 'B1', position: 'inside' },
   });
 
-  await expectItemToBeChildOf(page, expect, 'A', 'B1');
+  await expectItemToBeChildOf(page, expect, 'Z', 'B1');
 });
 
 test('Last item E can be moved before first item A', async ({ page }) => {
@@ -157,7 +157,7 @@ test('Last item E can be moved before first item A', async ({ page }) => {
   await expectItemBefore(page, expect, 'E', 'A');
 });
 
-test('First item A can be moved after last item E', async ({ page }) => {
+test('First item A can be moved after last item E and keep Z as child', async ({ page }) => {
   await page.goto('/');
 
   await dragItem({
@@ -168,4 +168,25 @@ test('First item A can be moved after last item E', async ({ page }) => {
   });
 
   await expectItemBefore(page, expect, 'E', 'A');
+  await expectItemToBeChildOf(page, expect, 'Z', 'A');
+});
+
+test('Programmatic button can move B1 after Z', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Move B1 after Z', exact: true }).click();
+
+  await expectItemBefore(page, expect, 'Z', 'B1');
+  await expectItemToBeChildOf(page, expect, 'B1', 'A');
+  await expectItemNotToBeChildOf(page, expect, 'B1', 'B');
+});
+
+test('Reset tree restores the original parent after a programmatic move', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Move B1 after Z', exact: true }).click();
+  await page.getByRole('button', { name: 'Reset tree', exact: true }).click();
+
+  await expectItemToBeChildOf(page, expect, 'B1', 'B');
+  await expectItemNotToBeChildOf(page, expect, 'B1', 'A');
 });

--- a/src/SortableTree/SortableTree.tsx
+++ b/src/SortableTree/SortableTree.tsx
@@ -23,6 +23,7 @@ import { SortableContext, arrayMove, verticalListSortingStrategy } from '@dnd-ki
 
 import {
   buildFlattenedItems,
+  getTreeItemMoveResult,
   getProjection,
   getChildCount,
   getChildrenCountById,
@@ -31,7 +32,6 @@ import {
   setTreeItemProperties,
 } from './utilities';
 import type {
-  DropResult,
   FlattenedItem,
   SensorContext,
   SortableTreeProps,
@@ -223,7 +223,7 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
         const sortedItems = arrayMove(clonedItems, activeIndex, overIndex);
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const newItems = sortedItems.map(({ depth, index, ...rest }) => rest) as TreeItems<T>;
-        const result = findItemActualIndex(newItems, clonedItems[activeIndex].id);
+        const result = getTreeItemMoveResult(newItems, clonedItems[activeIndex].id);
 
         setTreeItems(newItems);
         onDragEnd?.(result);
@@ -416,34 +416,6 @@ const adjustTranslate: Modifier = ({ transform }) => {
     y: transform.y - 25,
   };
 };
-
-function findItemActualIndex(items: TreeItems, targetId: UniqueIdentifier): DropResult | null {
-  const targetItem = items.find((item) => item.id === targetId);
-
-  if (!targetItem) {
-    return null;
-  }
-
-  const parentId = targetItem.parentId ?? null;
-  let index = -1;
-  let siblingIndex = 0;
-
-  for (const item of items) {
-    if (item.parentId === parentId) {
-      if (item.id === targetId) {
-        index = siblingIndex;
-        break;
-      }
-      siblingIndex += 1;
-    }
-  }
-
-  if (index === -1) {
-    return null;
-  }
-
-  return { index, parent: parentId, movedItem: targetItem };
-}
 
 export const SortableTree = <T extends TreeItem = TreeItem>(props: SortableTreeProps<T>) => {
   return <PrivateSortableTree {...props} />;

--- a/src/SortableTree/index.ts
+++ b/src/SortableTree/index.ts
@@ -6,6 +6,12 @@ export {
   setTreeItemProperties,
   removeItemById,
   getItemById,
+  getTreeItemMoveResult,
   convertTreeToFlatItems,
+  moveTreeItem,
+  moveItemBefore,
+  moveItemAfter,
+  moveItemInside,
 } from './utilities';
+export type { MoveTreeItemPosition } from './utilities';
 export { createSortableTreeGlobalStyles } from './createSortableTreeGlobalStyles';

--- a/src/SortableTree/types.ts
+++ b/src/SortableTree/types.ts
@@ -141,7 +141,7 @@ export interface SortableTreeProps<T extends TreeItem = TreeItem> {
    * Callback function called when a drag operation ends.
    * @param result - An object containing information about the drag operation.
    */
-  onDragEnd?: (result: DropResult) => void;
+  onDragEnd?: (result: DropResult<T>) => void;
 
   /**
    * Callback function called when an item in the tree is clicked.
@@ -161,11 +161,11 @@ export interface SortableTreeProps<T extends TreeItem = TreeItem> {
 /**
  * Represents the result of a drag operation in the tree.
  */
-export type DropResult = {
+export type DropResult<T extends TreeItem = TreeItem> = {
   /**
    * The item that was dragged.
    */
-  movedItem: TreeItem;
+  movedItem: T;
 
   /**
    * The new parent of the dragged item, or null if it's now a root item.
@@ -176,6 +176,21 @@ export type DropResult = {
    * The new index of the dragged item within its parent's children array.
    */
   index: number;
+
+  /**
+   * The id of the previous sibling in the new position, or null when the item is first.
+   */
+  beforeItemId?: UniqueIdentifier | null;
+
+  /**
+   * The id of the next sibling in the new position, or null when the item is last.
+   */
+  afterItemId?: UniqueIdentifier | null;
 } | null;
+
+export type MoveTreeItemResult<T extends TreeItem = TreeItem> = {
+  items: TreeItems<T>;
+  result: DropResult<T>;
+};
 
 export type { UniqueIdentifier } from '@dnd-kit/core';

--- a/src/SortableTree/utilities.ts
+++ b/src/SortableTree/utilities.ts
@@ -1,7 +1,14 @@
 import type { UniqueIdentifier } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
 
-import type { FlattenedItem, TreeItem, TreeItems, TreeItemsWithChildren } from './types';
+import type {
+  DropResult,
+  FlattenedItem,
+  MoveTreeItemResult,
+  TreeItem,
+  TreeItems,
+  TreeItemsWithChildren,
+} from './types';
 
 export const iOS = /iPad|iPhone|iPod/.test(navigator.platform);
 
@@ -238,8 +245,43 @@ export function setTreeItemProperties<T extends TreeItem>(
 export function getItemById<T extends TreeItem>(
   items: TreeItems<T>,
   id: UniqueIdentifier,
-): TreeItem<T> | undefined {
+): T | undefined {
   return items.find((item) => item.id === id);
+}
+
+export function getTreeItemMoveResult<T extends TreeItem>(
+  items: TreeItems<T>,
+  targetId: UniqueIdentifier,
+): DropResult<T> {
+  const targetItem = items.find((item) => item.id === targetId);
+
+  if (!targetItem) {
+    return null;
+  }
+
+  const { childrenByParentId, normalizedParentById } = buildChildrenByParentId(items);
+  const parentId = normalizedParentById.get(targetId) ?? null;
+  const siblings = childrenByParentId.get(parentId) ?? [];
+  const index = siblings.findIndex((sibling) => sibling.id === targetId);
+
+  if (index === -1) {
+    return null;
+  }
+
+  const beforeItemId = index > 0 ? siblings[index - 1].id : null;
+  const afterItemId = index < siblings.length - 1 ? siblings[index + 1].id : null;
+  const movedItem = {
+    ...targetItem,
+    parentId,
+  };
+
+  return {
+    movedItem,
+    parent: parentId,
+    index,
+    beforeItemId,
+    afterItemId,
+  };
 }
 
 export function getChildCount(items: TreeItems, id: UniqueIdentifier) {
@@ -263,4 +305,184 @@ export function getChildrenCountById<T extends TreeItem>(items: TreeItems<T>) {
 export function removeChildrenOf(items: FlattenedItem[], ids: UniqueIdentifier[]) {
   const descendantIds = getDescendantIds(items, ids);
   return items.filter((item) => !descendantIds.has(item.id));
+}
+
+export type MoveTreeItemPosition = 'before' | 'after' | 'inside';
+
+function getTreeDescendantIds<T extends TreeItem>(
+  childrenByParentId: Map<ParentId, T[]>,
+  itemId: UniqueIdentifier,
+): Set<UniqueIdentifier> {
+  const descendants = new Set<UniqueIdentifier>();
+  const queue: UniqueIdentifier[] = [itemId];
+
+  while (queue.length > 0) {
+    const currentId = queue.shift();
+    if (currentId == null) {
+      continue;
+    }
+
+    const children = childrenByParentId.get(currentId) ?? [];
+    for (const child of children) {
+      if (descendants.has(child.id)) {
+        continue;
+      }
+
+      descendants.add(child.id);
+      queue.push(child.id);
+    }
+  }
+
+  return descendants;
+}
+
+function flattenFromChildrenMap<T extends TreeItem>(
+  itemById: Map<UniqueIdentifier, T>,
+  childrenByParentId: Map<ParentId, UniqueIdentifier[]>,
+): TreeItems<T> {
+  const result: TreeItems<T> = [];
+  const visited = new Set<UniqueIdentifier>();
+
+  const visit = (parentId: ParentId) => {
+    const children = childrenByParentId.get(parentId) ?? [];
+
+    for (const childId of children) {
+      if (visited.has(childId)) {
+        continue;
+      }
+
+      const child = itemById.get(childId);
+      if (!child) {
+        continue;
+      }
+
+      visited.add(childId);
+      result.push(child);
+      visit(childId);
+    }
+  };
+
+  visit(null);
+
+  // Safety net for disconnected/cyclic data.
+  for (const item of itemById.values()) {
+    if (visited.has(item.id)) {
+      continue;
+    }
+    result.push(item);
+  }
+
+  return result;
+}
+
+export function moveTreeItem<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemId: UniqueIdentifier,
+  targetItemId: UniqueIdentifier,
+  position: MoveTreeItemPosition,
+): MoveTreeItemResult<T> {
+  if (itemId === targetItemId) {
+    return { items, result: null };
+  }
+
+  const { childrenByParentId, normalizedParentById } = buildChildrenByParentId(items);
+
+  const itemById = new Map<UniqueIdentifier, T>();
+  for (const item of items) {
+    itemById.set(item.id, item);
+  }
+
+  const item = itemById.get(itemId);
+  const target = itemById.get(targetItemId);
+
+  if (!item || !target) {
+    return { items, result: null };
+  }
+
+  const descendantsOfItem = getTreeDescendantIds(childrenByParentId, itemId);
+  if (descendantsOfItem.has(targetItemId)) {
+    return { items, result: null };
+  }
+
+  const siblingsByParentId = new Map<ParentId, UniqueIdentifier[]>();
+
+  for (const [parentId, siblings] of childrenByParentId.entries()) {
+    siblingsByParentId.set(
+      parentId,
+      siblings.map((sibling) => sibling.id),
+    );
+  }
+
+  const itemParentId = normalizedParentById.get(itemId) ?? null;
+  const itemSiblings = siblingsByParentId.get(itemParentId) ?? [];
+  const itemIndex = itemSiblings.indexOf(itemId);
+
+  if (itemIndex >= 0) {
+    itemSiblings.splice(itemIndex, 1);
+  }
+
+  let destinationParentId: ParentId;
+  let destinationIndex: number;
+
+  if (position === 'inside') {
+    destinationParentId = targetItemId;
+    const destinationSiblings = siblingsByParentId.get(destinationParentId) ?? [];
+    destinationIndex = destinationSiblings.length;
+  } else {
+    destinationParentId = normalizedParentById.get(targetItemId) ?? null;
+    const destinationSiblings = siblingsByParentId.get(destinationParentId) ?? [];
+    const targetIndex = destinationSiblings.indexOf(targetItemId);
+
+    if (targetIndex < 0) {
+      return { items, result: null };
+    }
+
+    destinationIndex = position === 'before' ? targetIndex : targetIndex + 1;
+  }
+
+  const destinationSiblings = siblingsByParentId.get(destinationParentId) ?? [];
+
+  if (!siblingsByParentId.has(destinationParentId)) {
+    siblingsByParentId.set(destinationParentId, destinationSiblings);
+  }
+
+  const boundedDestinationIndex = Math.min(
+    Math.max(destinationIndex, 0),
+    destinationSiblings.length,
+  );
+  destinationSiblings.splice(boundedDestinationIndex, 0, itemId);
+
+  const nextItemById = new Map(itemById);
+  nextItemById.set(itemId, { ...item, parentId: destinationParentId });
+
+  const nextItems = flattenFromChildrenMap(nextItemById, siblingsByParentId);
+
+  return {
+    items: nextItems,
+    result: getTreeItemMoveResult(nextItems, itemId),
+  };
+}
+
+export function moveItemBefore<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemId: UniqueIdentifier,
+  targetItemId: UniqueIdentifier,
+): MoveTreeItemResult<T> {
+  return moveTreeItem(items, itemId, targetItemId, 'before');
+}
+
+export function moveItemAfter<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemId: UniqueIdentifier,
+  targetItemId: UniqueIdentifier,
+): MoveTreeItemResult<T> {
+  return moveTreeItem(items, itemId, targetItemId, 'after');
+}
+
+export function moveItemInside<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemId: UniqueIdentifier,
+  targetItemId: UniqueIdentifier,
+): MoveTreeItemResult<T> {
+  return moveTreeItem(items, itemId, targetItemId, 'inside');
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,12 +3,16 @@ import { StrictMode, useState } from 'react';
 import { Handle } from './SortableTree/components/Handle';
 import {
   createSortableTreeGlobalStyles,
+  moveItemAfter,
+  moveItemBefore,
+  moveItemInside,
   SortableTree,
   TreeItem,
   TreeItems,
   TreeItemStructure,
 } from './index';
 import { RenderItemProps } from './SortableTree/components/TreeItem/TreeItem';
+import type { DropResult, MoveTreeItemResult } from './index';
 
 type CustomTreeItem = TreeItem<{
   icon?: string;
@@ -16,34 +20,29 @@ type CustomTreeItem = TreeItem<{
 }>;
 type MyTreeItem = TreeItems<CustomTreeItem>;
 
-// const BASE_TREE = [
-//   { id: 'a', label: 'A', parentId: null },
-//   { id: 'b', label: 'B', parentId: null },
-//   { id: 'b1', label: 'B1', parentId: 'b' },
-//   { id: 'c', label: 'C', parentId: null },
-//   { id: 'd', label: 'D', parentId: null },
-//   { id: 'e', label: 'E', parentId: null },
-// ];
-
-import { convertTreeToFlatItems } from './index';
-
-const LEGACY_TREE = [
-  { id: 'a', label: 'A', children: [] },
-  {
-    id: 'b',
-    label: 'B',
-    children: [{ id: 'b1', label: 'B1', children: [] }],
-  },
-  { id: 'c', label: 'C', children: [] },
-  { id: 'd', label: 'D', children: [] },
-  { id: 'e', label: 'E', children: [] },
+const BASE_TREE: MyTreeItem = [
+  { id: 'a', label: 'A', parentId: null },
+  { id: 'z', label: 'Z', parentId: 'a' },
+  { id: 'b', label: 'B', parentId: null },
+  { id: 'b1', label: 'B1', parentId: 'b' },
+  { id: 'c', label: 'C', parentId: null },
+  { id: 'd', label: 'D', parentId: null },
+  { id: 'e', label: 'E', parentId: null },
 ];
-
-const BASE_TREE = convertTreeToFlatItems(LEGACY_TREE);
 
 const App = () => {
   const [treeItems, setTreeItems] = useState<MyTreeItem>(BASE_TREE);
-  console.log(treeItems);
+  const [lastMoveResult, setLastMoveResult] = useState<DropResult<CustomTreeItem>>(null);
+
+  const runProgrammaticMove = (
+    moveFn: (items: MyTreeItem) => MoveTreeItemResult<CustomTreeItem>,
+  ) => {
+    setTreeItems((currentItems) => {
+      const { items, result } = moveFn(currentItems);
+      setLastMoveResult(result);
+      return items;
+    });
+  };
 
   const MyCustomTreeItem = (props: RenderItemProps<CustomTreeItem>) => {
     const useSortableTreeGlobalStyles = createSortableTreeGlobalStyles({
@@ -68,14 +67,45 @@ const App = () => {
   };
 
   return (
-    <SortableTree<CustomTreeItem>
-      isCollapsible
-      showDropIndicator
-      items={treeItems}
-      setItems={setTreeItems}
-      renderItem={MyCustomTreeItem}
-      onDragEnd={(r) => console.log(r)}
-    />
+    <div style={{ display: 'grid', gap: 12 }}>
+      <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+        <button onClick={() => runProgrammaticMove((items) => moveItemAfter(items, 'b1', 'z'))}>
+          Move B1 after Z
+        </button>
+        <button onClick={() => runProgrammaticMove((items) => moveItemBefore(items, 'd', 'b'))}>
+          Move D before B
+        </button>
+        <button onClick={() => runProgrammaticMove((items) => moveItemInside(items, 'e', 'a'))}>
+          Move E inside A
+        </button>
+        <button
+          onClick={() => {
+            setTreeItems(BASE_TREE);
+            setLastMoveResult(null);
+          }}
+        >
+          Reset tree
+        </button>
+      </div>
+
+      <pre style={{ margin: 0, padding: 12, border: '1px solid #ddd' }}>
+        {lastMoveResult ?
+          JSON.stringify(lastMoveResult, null, 2)
+        : 'Move result will appear here (programmatic or drag-and-drop).'}
+      </pre>
+
+      <SortableTree<CustomTreeItem>
+        isCollapsible
+        showDropIndicator
+        items={treeItems}
+        setItems={setTreeItems}
+        renderItem={MyCustomTreeItem}
+        onDragEnd={(result) => {
+          setLastMoveResult(result);
+          console.log(result);
+        }}
+      />
+    </div>
   );
 };
 


### PR DESCRIPTION
This PR adds experimental functions to move items programatically. Also, we added the `afterItemId` and `beforeItemId` properties when sorting an item. This is useful for recalculating the item's new value when using a lexicographical approach.


No breaking changes were added.