### PR TITLE
Add explicit bulk move helpers and overlap semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,24 @@ type MoveTreeItemsOptions = {
 };
 ```
 
+This option exists because overlapping selections can be interpreted in two valid ways.
+If a user selects both a parent item and one of its descendants, the library needs to know
+whether the descendant should stay inside the moved parent subtree, or be extracted and moved
+as its own item too.
+
+Example:
+
+```txt
+A
+  A.1
+C
+```
+
+If `A` and `A.1` are both selected and moved `inside` `C`:
+
+- `preserve-subtrees` (default): `A` is treated as the effective move root, so `A.1` stays inside `A`.
+- `extract-selected-descendants`: both explicit selections are honored, so `A` and `A.1` become siblings under `C`.
+
 ### MoveTreeItemsResult
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -332,6 +332,24 @@ type MoveTreeItemResult<T extends TreeItem = TreeItem> = {
 };
 ```
 
+### MoveTreeItemsOptions
+
+```ts
+type MoveTreeItemsOptions = {
+  overlapBehavior?: 'preserve-subtrees' | 'extract-selected-descendants';
+};
+```
+
+### MoveTreeItemsResult
+
+```ts
+type MoveTreeItemsResult<T extends TreeItem = TreeItem> = {
+  items: TreeItems<T>;
+  results: DropResult<T>[];
+  movedItemIds: UniqueIdentifier[];
+};
+```
+
 ---
 
 ## Helper Functions
@@ -381,6 +399,18 @@ function moveTreeItem<T extends TreeItem>(
 ): MoveTreeItemResult<T>;
 ```
 
+### moveTreeItems
+
+```ts
+function moveTreeItems<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemIds: UniqueIdentifier[],
+  targetItemId: UniqueIdentifier,
+  position: 'before' | 'after' | 'inside',
+  options?: MoveTreeItemsOptions,
+): MoveTreeItemsResult<T>;
+```
+
 ### moveItemBefore / moveItemAfter / moveItemInside
 
 ```ts
@@ -401,6 +431,31 @@ function moveItemInside<T extends TreeItem>(
   itemId: UniqueIdentifier,
   targetItemId: UniqueIdentifier,
 ): MoveTreeItemResult<T>;
+```
+
+### moveItemsBefore / moveItemsAfter / moveItemsInside
+
+```ts
+function moveItemsBefore<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemIds: UniqueIdentifier[],
+  targetItemId: UniqueIdentifier,
+  options?: MoveTreeItemsOptions,
+): MoveTreeItemsResult<T>;
+
+function moveItemsAfter<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemIds: UniqueIdentifier[],
+  targetItemId: UniqueIdentifier,
+  options?: MoveTreeItemsOptions,
+): MoveTreeItemsResult<T>;
+
+function moveItemsInside<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemIds: UniqueIdentifier[],
+  targetItemId: UniqueIdentifier,
+  options?: MoveTreeItemsOptions,
+): MoveTreeItemsResult<T>;
 ```
 
 ---

--- a/e2e/tree.spec.ts
+++ b/e2e/tree.spec.ts
@@ -190,3 +190,53 @@ test('Reset tree restores the original parent after a programmatic move', async 
   await expectItemToBeChildOf(page, expect, 'B1', 'B');
   await expectItemNotToBeChildOf(page, expect, 'B1', 'A');
 });
+
+test('Programmatic button can move A and B before E as a bulk block', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Move A + B before E', exact: true }).click();
+
+  await expectItemBefore(page, expect, 'D', 'A');
+  await expectItemBefore(page, expect, 'A', 'B');
+  await expectItemBefore(page, expect, 'B', 'E');
+  await expectItemToBeChildOf(page, expect, 'Z', 'A');
+  await expectItemToBeChildOf(page, expect, 'B1', 'B');
+});
+
+test('Programmatic button can move A and B after C as a bulk block', async ({ page }) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Move A + B after C', exact: true }).click();
+
+  await expectItemBefore(page, expect, 'C', 'A');
+  await expectItemBefore(page, expect, 'A', 'B');
+  await expectItemBefore(page, expect, 'B', 'D');
+  await expectItemToBeChildOf(page, expect, 'Z', 'A');
+  await expectItemToBeChildOf(page, expect, 'B1', 'B');
+});
+
+test('Programmatic button can move A and B inside C while preserving their subtrees', async ({
+  page,
+}) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Move A + B inside C', exact: true }).click();
+
+  await expectItemToBeChildOf(page, expect, 'A', 'C');
+  await expectItemToBeChildOf(page, expect, 'B', 'C');
+  await expectItemToBeChildOf(page, expect, 'Z', 'A');
+  await expectItemToBeChildOf(page, expect, 'B1', 'B');
+});
+
+test('Programmatic button can extract a selected descendant and move it with its parent', async ({
+  page,
+}) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Extract A + Z inside C', exact: true }).click();
+
+  await expectItemToBeChildOf(page, expect, 'A', 'C');
+  await expectItemToBeChildOf(page, expect, 'Z', 'C');
+  await expectItemNotToBeChildOf(page, expect, 'Z', 'A');
+  await expectItemBefore(page, expect, 'A', 'Z');
+});

--- a/src/SortableTree/index.ts
+++ b/src/SortableTree/index.ts
@@ -8,10 +8,14 @@ export {
   getItemById,
   getTreeItemMoveResult,
   convertTreeToFlatItems,
+  moveTreeItems,
   moveTreeItem,
   moveItemBefore,
   moveItemAfter,
   moveItemInside,
+  moveItemsBefore,
+  moveItemsAfter,
+  moveItemsInside,
 } from './utilities';
 export type { MoveTreeItemPosition } from './utilities';
 export { createSortableTreeGlobalStyles } from './createSortableTreeGlobalStyles';

--- a/src/SortableTree/types.ts
+++ b/src/SortableTree/types.ts
@@ -193,4 +193,22 @@ export type MoveTreeItemResult<T extends TreeItem = TreeItem> = {
   result: DropResult<T>;
 };
 
+export type MoveTreeItemsOverlapBehavior = 'preserve-subtrees' | 'extract-selected-descendants';
+
+export type MoveTreeItemsOptions = {
+  /**
+   * Controls how overlapping selections are handled.
+   * - preserve-subtrees: descendants of selected parents are ignored as separate move roots
+   * - extract-selected-descendants: explicitly selected descendants are detached and moved too
+   * @default 'preserve-subtrees'
+   */
+  overlapBehavior?: MoveTreeItemsOverlapBehavior;
+};
+
+export type MoveTreeItemsResult<T extends TreeItem = TreeItem> = {
+  items: TreeItems<T>;
+  results: DropResult<T>[];
+  movedItemIds: UniqueIdentifier[];
+};
+
 export type { UniqueIdentifier } from '@dnd-kit/core';

--- a/src/SortableTree/utilities.ts
+++ b/src/SortableTree/utilities.ts
@@ -5,6 +5,8 @@ import type {
   DropResult,
   FlattenedItem,
   MoveTreeItemResult,
+  MoveTreeItemsOptions,
+  MoveTreeItemsResult,
   TreeItem,
   TreeItems,
   TreeItemsWithChildren,
@@ -113,6 +115,67 @@ function buildChildrenByParentId<T extends TreeItem>(items: TreeItems<T>) {
   }
 
   return { childrenByParentId, normalizedParentById };
+}
+
+function getOrderedUniqueItemIds<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemIds: UniqueIdentifier[],
+): UniqueIdentifier[] {
+  const remainingIds = new Set(itemIds);
+
+  if (remainingIds.size === 0) {
+    return [];
+  }
+
+  const orderedIds: UniqueIdentifier[] = [];
+
+  for (const item of buildFlattenedItems(items)) {
+    if (!remainingIds.has(item.id)) {
+      continue;
+    }
+
+    orderedIds.push(item.id);
+    remainingIds.delete(item.id);
+  }
+
+  return orderedIds;
+}
+
+function hasSelectedAncestor(
+  id: UniqueIdentifier,
+  selectedIds: Set<UniqueIdentifier>,
+  normalizedParentById: Map<UniqueIdentifier, ParentId>,
+): boolean {
+  let parentId = normalizedParentById.get(id) ?? null;
+
+  while (parentId != null) {
+    if (selectedIds.has(parentId)) {
+      return true;
+    }
+
+    parentId = normalizedParentById.get(parentId) ?? null;
+  }
+
+  return false;
+}
+
+function getEffectiveMovedItemIds<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemIds: UniqueIdentifier[],
+  overlapBehavior: MoveTreeItemsOptions['overlapBehavior'] = 'preserve-subtrees',
+): UniqueIdentifier[] {
+  const orderedItemIds = getOrderedUniqueItemIds(items, itemIds);
+
+  if (overlapBehavior === 'extract-selected-descendants') {
+    return orderedItemIds;
+  }
+
+  const { normalizedParentById } = buildChildrenByParentId(items);
+  const selectedIds = new Set(orderedItemIds);
+
+  return orderedItemIds.filter(
+    (itemId) => !hasSelectedAncestor(itemId, selectedIds, normalizedParentById),
+  );
 }
 
 function getDescendantIds<T extends TreeItem>(
@@ -375,33 +438,40 @@ function flattenFromChildrenMap<T extends TreeItem>(
   return result;
 }
 
-export function moveTreeItem<T extends TreeItem>(
+export function moveTreeItems<T extends TreeItem>(
   items: TreeItems<T>,
-  itemId: UniqueIdentifier,
+  itemIds: UniqueIdentifier[],
   targetItemId: UniqueIdentifier,
   position: MoveTreeItemPosition,
-): MoveTreeItemResult<T> {
-  if (itemId === targetItemId) {
-    return { items, result: null };
+  options: MoveTreeItemsOptions = {},
+): MoveTreeItemsResult<T> {
+  const movedItemIds = getEffectiveMovedItemIds(items, itemIds, options.overlapBehavior);
+
+  if (movedItemIds.length === 0) {
+    return { items, results: [], movedItemIds: [] };
+  }
+
+  if (movedItemIds.includes(targetItemId)) {
+    return { items, results: [], movedItemIds: [] };
   }
 
   const { childrenByParentId, normalizedParentById } = buildChildrenByParentId(items);
-
   const itemById = new Map<UniqueIdentifier, T>();
+
   for (const item of items) {
     itemById.set(item.id, item);
   }
 
-  const item = itemById.get(itemId);
-  const target = itemById.get(targetItemId);
-
-  if (!item || !target) {
-    return { items, result: null };
+  if (!itemById.has(targetItemId)) {
+    return { items, results: [], movedItemIds: [] };
   }
 
-  const descendantsOfItem = getTreeDescendantIds(childrenByParentId, itemId);
-  if (descendantsOfItem.has(targetItemId)) {
-    return { items, result: null };
+  for (const itemId of movedItemIds) {
+    const descendantsOfItem = getTreeDescendantIds(childrenByParentId, itemId);
+
+    if (descendantsOfItem.has(targetItemId)) {
+      return { items, results: [], movedItemIds: [] };
+    }
   }
 
   const siblingsByParentId = new Map<ParentId, UniqueIdentifier[]>();
@@ -413,12 +483,14 @@ export function moveTreeItem<T extends TreeItem>(
     );
   }
 
-  const itemParentId = normalizedParentById.get(itemId) ?? null;
-  const itemSiblings = siblingsByParentId.get(itemParentId) ?? [];
-  const itemIndex = itemSiblings.indexOf(itemId);
+  for (const itemId of movedItemIds) {
+    const itemParentId = normalizedParentById.get(itemId) ?? null;
+    const itemSiblings = siblingsByParentId.get(itemParentId) ?? [];
+    const itemIndex = itemSiblings.indexOf(itemId);
 
-  if (itemIndex >= 0) {
-    itemSiblings.splice(itemIndex, 1);
+    if (itemIndex >= 0) {
+      itemSiblings.splice(itemIndex, 1);
+    }
   }
 
   let destinationParentId: ParentId;
@@ -434,7 +506,7 @@ export function moveTreeItem<T extends TreeItem>(
     const targetIndex = destinationSiblings.indexOf(targetItemId);
 
     if (targetIndex < 0) {
-      return { items, result: null };
+      return { items, results: [], movedItemIds: [] };
     }
 
     destinationIndex = position === 'before' ? targetIndex : targetIndex + 1;
@@ -450,16 +522,52 @@ export function moveTreeItem<T extends TreeItem>(
     Math.max(destinationIndex, 0),
     destinationSiblings.length,
   );
-  destinationSiblings.splice(boundedDestinationIndex, 0, itemId);
+  destinationSiblings.splice(boundedDestinationIndex, 0, ...movedItemIds);
 
   const nextItemById = new Map(itemById);
-  nextItemById.set(itemId, { ...item, parentId: destinationParentId });
+
+  for (const itemId of movedItemIds) {
+    const item = itemById.get(itemId);
+
+    if (!item) {
+      continue;
+    }
+
+    nextItemById.set(itemId, {
+      ...item,
+      parentId: destinationParentId,
+    });
+  }
 
   const nextItems = flattenFromChildrenMap(nextItemById, siblingsByParentId);
+  const results = movedItemIds.reduce<DropResult<T>[]>((acc, itemId) => {
+    const result = getTreeItemMoveResult(nextItems, itemId);
+
+    if (result) {
+      acc.push(result);
+    }
+
+    return acc;
+  }, []);
 
   return {
     items: nextItems,
-    result: getTreeItemMoveResult(nextItems, itemId),
+    results,
+    movedItemIds,
+  };
+}
+
+export function moveTreeItem<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemId: UniqueIdentifier,
+  targetItemId: UniqueIdentifier,
+  position: MoveTreeItemPosition,
+): MoveTreeItemResult<T> {
+  const { items: nextItems, results } = moveTreeItems(items, [itemId], targetItemId, position);
+
+  return {
+    items: nextItems,
+    result: results[0] ?? null,
   };
 }
 
@@ -485,4 +593,31 @@ export function moveItemInside<T extends TreeItem>(
   targetItemId: UniqueIdentifier,
 ): MoveTreeItemResult<T> {
   return moveTreeItem(items, itemId, targetItemId, 'inside');
+}
+
+export function moveItemsBefore<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemIds: UniqueIdentifier[],
+  targetItemId: UniqueIdentifier,
+  options?: MoveTreeItemsOptions,
+): MoveTreeItemsResult<T> {
+  return moveTreeItems(items, itemIds, targetItemId, 'before', options);
+}
+
+export function moveItemsAfter<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemIds: UniqueIdentifier[],
+  targetItemId: UniqueIdentifier,
+  options?: MoveTreeItemsOptions,
+): MoveTreeItemsResult<T> {
+  return moveTreeItems(items, itemIds, targetItemId, 'after', options);
+}
+
+export function moveItemsInside<T extends TreeItem>(
+  items: TreeItems<T>,
+  itemIds: UniqueIdentifier[],
+  targetItemId: UniqueIdentifier,
+  options?: MoveTreeItemsOptions,
+): MoveTreeItemsResult<T> {
+  return moveTreeItems(items, itemIds, targetItemId, 'inside', options);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,19 +6,26 @@ import {
   moveItemAfter,
   moveItemBefore,
   moveItemInside,
+  moveItemsAfter,
+  moveItemsBefore,
+  moveItemsInside,
   SortableTree,
   TreeItem,
   TreeItems,
   TreeItemStructure,
 } from './index';
 import { RenderItemProps } from './SortableTree/components/TreeItem/TreeItem';
-import type { DropResult, MoveTreeItemResult } from './index';
+import type { DropResult, MoveTreeItemResult, MoveTreeItemsResult } from './index';
 
 type CustomTreeItem = TreeItem<{
   icon?: string;
   description?: string;
 }>;
 type MyTreeItem = TreeItems<CustomTreeItem>;
+type LastMoveResult = DropResult<CustomTreeItem> | DropResult<CustomTreeItem>[];
+type ProgrammaticMoveResult =
+  | MoveTreeItemResult<CustomTreeItem>
+  | MoveTreeItemsResult<CustomTreeItem>;
 
 const BASE_TREE: MyTreeItem = [
   { id: 'a', label: 'A', parentId: null },
@@ -32,15 +39,19 @@ const BASE_TREE: MyTreeItem = [
 
 const App = () => {
   const [treeItems, setTreeItems] = useState<MyTreeItem>(BASE_TREE);
-  const [lastMoveResult, setLastMoveResult] = useState<DropResult<CustomTreeItem>>(null);
+  const [lastMoveResult, setLastMoveResult] = useState<LastMoveResult>(null);
 
-  const runProgrammaticMove = (
-    moveFn: (items: MyTreeItem) => MoveTreeItemResult<CustomTreeItem>,
-  ) => {
+  const runProgrammaticMove = (moveFn: (items: MyTreeItem) => ProgrammaticMoveResult) => {
     setTreeItems((currentItems) => {
-      const { items, result } = moveFn(currentItems);
-      setLastMoveResult(result);
-      return items;
+      const moveResult = moveFn(currentItems);
+
+      if ('results' in moveResult) {
+        setLastMoveResult(moveResult.results);
+      } else {
+        setLastMoveResult(moveResult.result);
+      }
+
+      return moveResult.items;
     });
   };
 
@@ -77,6 +88,32 @@ const App = () => {
         </button>
         <button onClick={() => runProgrammaticMove((items) => moveItemInside(items, 'e', 'a'))}>
           Move E inside A
+        </button>
+        <button
+          onClick={() => runProgrammaticMove((items) => moveItemsBefore(items, ['a', 'b'], 'e'))}
+        >
+          Move A + B before E
+        </button>
+        <button
+          onClick={() => runProgrammaticMove((items) => moveItemsAfter(items, ['a', 'b'], 'c'))}
+        >
+          Move A + B after C
+        </button>
+        <button
+          onClick={() => runProgrammaticMove((items) => moveItemsInside(items, ['a', 'b'], 'c'))}
+        >
+          Move A + B inside C
+        </button>
+        <button
+          onClick={() =>
+            runProgrammaticMove((items) =>
+              moveItemsInside(items, ['a', 'z'], 'c', {
+                overlapBehavior: 'extract-selected-descendants',
+              }),
+            )
+          }
+        >
+          Extract A + Z inside C
         </button>
         <button
           onClick={() => {


### PR DESCRIPTION
## Summary

This PR adds multiselection support by defining and implementing a programmatic bulk-move contract that lets us move items `before`, `after`, or `inside` another item, and by handling parent/child overlaps predictably.

## What Changed

- added bulk move utilities:
  - `moveTreeItems`
  - `moveItemsBefore`
  - `moveItemsAfter`
  - `moveItemsInside`
- kept single-item helpers explicit:
  - `moveItemBefore`
  - `moveItemAfter`
  - `moveItemInside`
- introduced `MoveTreeItemsOptions` with explicit overlap behavior:
  - `preserve-subtrees` (default)
  - `extract-selected-descendants`
- updated the playground and README with examples
- added E2E coverage for the new bulk move scenarios

## Bulk Move Contract
- bulk moves preserve the current tree order of the moved items
- each moved item preserves its internal subtree structure
- by default, overlapping parent/child selections preserve the parent subtree
- when `extract-selected-descendants` is used, explicitly selected descendants are detached and moved as separate items
- invalid moves into a moved item or one of its descendants are rejected

## Why

This gives us a clear and reusable programmatic contract for bulk tree operations before introducing UI multiselection and multi-drag behavior.

It also keeps the public API easier to understand by separating singular and plural move helpers, instead of overloading the same function names with different return shapes.

## Verification

- `npm run build`
- `npm run e2e`

The E2E cases serve as executable documentation for the supported move semantics and edge cases.