### PR TITLE
feat: add optional auto-expand on hover while dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ const BASE_TREE = [
 <SortableTree<CustomTreeItem>
   isCollapsible
   showDropIndicator
+  autoExpandOnHoverDelay={600}
   items={items}
   setItems={setItems}
   renderItem={(props: RenderItemProps<CustomTreeItem>) => (
@@ -215,6 +216,8 @@ const BASE_TREE = [
   )}
 />;
 ```
+
+Use `autoExpandOnHoverDelay` when you want collapsed parents to expand while a user is dragging over a nesting position. This lets people continue navigating deeper into the tree without dropping the item first. The prop is optional, so consumers can decide whether to enable the behavior and how long the hover delay should be.
 
 ---
 
@@ -229,6 +232,7 @@ const BASE_TREE = [
 | `isCollapsible`           | `boolean`                                                       | `false`     | Determines if tree items can be collapsed/expanded.                                                                  |
 | `onLazyLoadChildren`      | `(id: UniqueIdentifier, isExpanding: boolean) => Promise<void>` | `undefined` | Callback for lazy loading child items when a parent is expanded. Useful for getting child items from an API endpoint |
 | `showDropIndicator`       | `boolean`                                                       | `false`     | Determines if a drop indicator should be shown when dragging items.                                                  |
+| `autoExpandOnHoverDelay`  | `number`                                                        | `undefined` | Automatically expands a collapsed parent after the given hover delay in milliseconds while dragging into it.         |
 | `isRemovable`             | `boolean`                                                       | `false`     | Determines if items can be removed from the tree.                                                                    |
 | `onRemoveItem`            | `(id: UniqueIdentifier) => void`                                | `undefined` | Callback function called when an item is removed from the tree.                                                      |
 | `allowNestedItemAddition` | `boolean`                                                       | `false`     | Determines if new items can be added as children to existing items.                                                  |

--- a/e2e/tree.spec.ts
+++ b/e2e/tree.spec.ts
@@ -4,6 +4,7 @@ import {
   expectItemBefore,
   expectItemNotToBeChildOf,
   expectItemToBeChildOf,
+  getTreeItem,
 } from './utils';
 
 test.afterEach(async ({ page }) => {
@@ -21,6 +22,31 @@ test('Item D becomes a child of C after drag and drop', async ({ page }) => {
   });
 
   await expectItemToBeChildOf(page, expect, 'D', 'C');
+});
+
+test('Collapsed parents auto-expand when dragging indicates nesting into them', async ({
+  page,
+}) => {
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Toggle A collapse', exact: true }).click();
+  await expect(getTreeItem(page, 'Z')).toHaveCount(0);
+
+  await dragItem({
+    page,
+    expect,
+    from: { name: 'C' },
+    to: { name: 'B', position: 'before', horizontalOffset: 80 },
+    beforeDrop: {
+      waitMs: 1500,
+      run: async ({ page, expect }) => {
+        await expect(getTreeItem(page, 'Z')).toHaveCount(1);
+      },
+      continueTo: { name: 'Z', position: 'before' },
+    },
+  });
+
+  await expectItemToBeChildOf(page, expect, 'C', 'A');
 });
 
 test('Item D is moved below C after drag and drop', async ({ page }) => {

--- a/e2e/utils/drag-item.ts
+++ b/e2e/utils/drag-item.ts
@@ -2,30 +2,41 @@ import type { Page, Expect } from '@playwright/test';
 import { getTreeItem } from './get-tree-item';
 
 type DragPosition = 'before' | 'after' | 'inside';
+type DragBounds = { x: number; y: number; width: number; height: number };
+
+interface DragTarget {
+  name: string;
+  position: DragPosition;
+  horizontalOffset?: number;
+}
 
 interface DragItemOptions {
   page: Page;
   expect: Expect;
   from: { name: string };
-  to: { name: string; position: DragPosition };
+  to: DragTarget;
+  beforeDrop?: {
+    waitMs?: number;
+    run?: (context: { page: Page; expect: Expect }) => Promise<void>;
+    continueTo?: DragTarget;
+  };
 }
 
-export async function dragItem({ page, expect, from, to }: DragItemOptions) {
-  const fromHandle = page.getByLabel(`Drag ${from.name}`, { exact: true });
-  const targetItem = getTreeItem(page, to.name).locator('[data-tree-draggable]');
+async function getDragCoordinates(
+  page: Page,
+  expect: Expect,
+  fromBox: DragBounds,
+  target: DragTarget,
+) {
+  const targetItem = getTreeItem(page, target.name).locator('[data-tree-draggable]');
 
-  await expect(fromHandle).toBeVisible();
   await expect(targetItem).toBeVisible();
 
-  const fromBox = await fromHandle.boundingBox();
   const targetBox = await targetItem.boundingBox();
 
-  if (!fromBox || !targetBox) {
+  if (!targetBox) {
     throw new Error('Could not determine bounding boxes for drag operation');
   }
-
-  const startX = fromBox.x + fromBox.width / 2;
-  const startY = fromBox.y + fromBox.height / 2;
 
   let endX = targetBox.x + 8;
   let endY = targetBox.y;
@@ -39,7 +50,7 @@ export async function dragItem({ page, expect, from, to }: DragItemOptions) {
    */
   const draggingUp = fromBox.y > targetBox.y;
 
-  switch (to.position) {
+  switch (target.position) {
     case 'before': {
       endY = targetBox.y + PADDING_Y;
 
@@ -61,25 +72,40 @@ export async function dragItem({ page, expect, from, to }: DragItemOptions) {
     }
 
     case 'inside': {
-      const draggableBox = await targetItem.boundingBox();
-
-      if (!draggableBox) {
-        throw new Error('Could not determine draggable item bounds');
-      }
-
-      endX = draggableBox.x + draggableBox.width * 0.25;
+      endX = targetBox.x + targetBox.width * 0.25;
 
       if (draggingUp) {
-        const result = draggableBox.y + draggableBox.height * 2;
-        endY = result;
+        endY = targetBox.y + targetBox.height * 2;
       } else {
-        const result = draggableBox.y + draggableBox.height * 0.75;
-        endY = result;
+        endY = targetBox.y + targetBox.height * 0.75;
       }
 
       break;
     }
   }
+
+  if (target.horizontalOffset != null) {
+    endX = Math.min(targetBox.x + targetBox.width - 8, targetBox.x + target.horizontalOffset);
+  }
+
+  return { endX, endY };
+}
+
+export async function dragItem({ page, expect, from, to, beforeDrop }: DragItemOptions) {
+  const fromHandle = page.getByLabel(`Drag ${from.name}`, { exact: true });
+
+  await expect(fromHandle).toBeVisible();
+
+  const fromBox = await fromHandle.boundingBox();
+
+  if (!fromBox) {
+    throw new Error('Could not determine draggable handle bounds');
+  }
+
+  const { endX, endY } = await getDragCoordinates(page, expect, fromBox, to);
+
+  const startX = fromBox.x + fromBox.width / 2;
+  const startY = fromBox.y + fromBox.height / 2;
 
   await page.mouse.move(startX, startY);
   await page.mouse.down();
@@ -88,6 +114,27 @@ export async function dragItem({ page, expect, from, to }: DragItemOptions) {
   await page.mouse.move(startX + 1, startY + 1);
 
   await page.mouse.move(endX, endY, { steps: 10 });
+
+  await page.evaluate(() => new Promise(requestAnimationFrame));
+
+  if (beforeDrop) {
+    await page.waitForTimeout(120);
+  }
+
+  if (beforeDrop?.waitMs) {
+    await page.waitForTimeout(beforeDrop.waitMs);
+  }
+
+  await page.evaluate(() => new Promise(requestAnimationFrame));
+
+  if (beforeDrop?.run) {
+    await beforeDrop.run({ page, expect });
+  }
+
+  if (beforeDrop?.continueTo) {
+    const nextTarget = await getDragCoordinates(page, expect, fromBox, beforeDrop.continueTo);
+    await page.mouse.move(nextTarget.endX, nextTarget.endY, { steps: 10 });
+  }
 
   await page.evaluate(() => new Promise(requestAnimationFrame));
   await page.waitForTimeout(120);

--- a/src/SortableTree/SortableTree.tsx
+++ b/src/SortableTree/SortableTree.tsx
@@ -71,6 +71,7 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
   isCollapsible,
   onLazyLoadChildren,
   showDropIndicator = false,
+  autoExpandOnHoverDelay,
   indentationWidth = 50,
   isRemovable,
   onRemoveItem,
@@ -87,6 +88,7 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
     parentId: UniqueIdentifier | null;
     overId: UniqueIdentifier;
   } | null>(null);
+  const autoExpandTimeoutRef = useRef<number | null>(null);
 
   const flatItems = useMemo(() => {
     return buildFlattenedItems(items);
@@ -165,6 +167,13 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
     };
   }, [flattenedItems, offsetLeft]);
 
+  const clearAutoExpandTimeout = useCallback(() => {
+    if (autoExpandTimeoutRef.current !== null) {
+      window.clearTimeout(autoExpandTimeoutRef.current);
+      autoExpandTimeoutRef.current = null;
+    }
+  }, []);
+
   const handleDragStart = useCallback(
     ({ active: { id: activeId } }: DragStartEvent) => {
       setActiveId(activeId);
@@ -193,13 +202,14 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
   }, []);
 
   const resetState = useCallback(() => {
+    clearAutoExpandTimeout();
     setOverId(null);
     setActiveId(null);
     setOffsetLeft(0);
     setCurrentPosition(null);
 
     document.body.style.setProperty('cursor', '');
-  }, []);
+  }, [clearAutoExpandTimeout]);
 
   const handleDragEnd = useCallback(
     ({ active, over }: DragEndEvent) => {
@@ -237,6 +247,40 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
     [setTreeItems],
   );
 
+  const setCollapsedState = useCallback(
+    (id: UniqueIdentifier, collapsed: boolean) => {
+      return setTreeItems((items) =>
+        setTreeItemProperties(items, id, () => {
+          return { collapsed } as Partial<T>;
+        }),
+      );
+    },
+    [setTreeItems],
+  );
+
+  const expandItem = useCallback(
+    ({
+      id,
+      canFetchChildren,
+      collapsed,
+    }: {
+      id: UniqueIdentifier;
+      canFetchChildren: TreeItem['canFetchChildren'];
+      collapsed: TreeItem['collapsed'];
+    }) => {
+      if (!collapsed) {
+        return;
+      }
+
+      if (canFetchChildren) {
+        return onLazyLoadChildren?.(id, true);
+      }
+
+      return setCollapsedState(id, false);
+    },
+    [onLazyLoadChildren, setCollapsedState],
+  );
+
   const handleCollapse = useCallback(
     ({
       id,
@@ -247,18 +291,64 @@ function PrivateSortableTree<T extends TreeItem = TreeItem>({
       canFetchChildren: TreeItem['canFetchChildren'];
       collapsed: TreeItem['collapsed'];
     }) => {
-      if (canFetchChildren) {
-        return onLazyLoadChildren?.(id, Boolean(collapsed));
+      if (collapsed) {
+        return expandItem({ id, canFetchChildren, collapsed });
       }
 
-      return setTreeItems((items) =>
-        setTreeItemProperties(items, id, (item) => {
-          return { collapsed: !item.collapsed } as T;
-        }),
-      );
+      if (canFetchChildren) {
+        return onLazyLoadChildren?.(id, false);
+      }
+
+      return setCollapsedState(id, true);
     },
-    [onLazyLoadChildren, setTreeItems],
+    [expandItem, onLazyLoadChildren, setCollapsedState],
   );
+
+  useEffect(() => {
+    clearAutoExpandTimeout();
+
+    const autoExpandTargetId = projected?.parentId;
+
+    if (autoExpandOnHoverDelay == null || !activeId || !autoExpandTargetId) {
+      return;
+    }
+
+    const targetItem = flatItems.find((item) => item.id === autoExpandTargetId);
+
+    if (!targetItem?.collapsed) {
+      return;
+    }
+
+    const hasChildren = (childrenCountById.get(autoExpandTargetId) ?? 0) > 0;
+    const canExpand = hasChildren || Boolean(targetItem.canFetchChildren);
+
+    if (!canExpand) {
+      return;
+    }
+
+    autoExpandTimeoutRef.current = window.setTimeout(() => {
+      expandItem({
+        id: targetItem.id,
+        canFetchChildren: targetItem.canFetchChildren,
+        collapsed: targetItem.collapsed,
+      });
+      autoExpandTimeoutRef.current = null;
+    }, autoExpandOnHoverDelay);
+
+    return clearAutoExpandTimeout;
+  }, [
+    activeId,
+    autoExpandOnHoverDelay,
+    childrenCountById,
+    clearAutoExpandTimeout,
+    expandItem,
+    flatItems,
+    projected,
+  ]);
+
+  useEffect(() => {
+    return clearAutoExpandTimeout;
+  }, [clearAutoExpandTimeout]);
 
   const getMovementAnnouncement = useCallback(
     (eventName: string, activeId: UniqueIdentifier, overId?: UniqueIdentifier) => {

--- a/src/SortableTree/types.ts
+++ b/src/SortableTree/types.ts
@@ -114,6 +114,12 @@ export interface SortableTreeProps<T extends TreeItem = TreeItem> {
   showDropIndicator?: boolean;
 
   /**
+   * When provided, automatically expands a collapsed item after it has been hovered
+   * for the given amount of time during a drag operation.
+   */
+  autoExpandOnHoverDelay?: number;
+
+  /**
    * Determines if items can be removed from the tree.
    * @default false
    */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import {
   moveItemsInside,
   removeItemById,
   removeItemsById,
+  setTreeItemProperties,
   SortableTree,
   TreeItem,
   TreeItems,
@@ -134,6 +135,15 @@ const App = () => {
           Remove A + Z
         </button>
         <button
+          onClick={() =>
+            setTreeItems((items) =>
+              setTreeItemProperties(items, 'a', (item) => ({ collapsed: !item.collapsed })),
+            )
+          }
+        >
+          Toggle A collapse
+        </button>
+        <button
           onClick={() => {
             setTreeItems(BASE_TREE);
             setLastMoveResult(null);
@@ -152,6 +162,7 @@ const App = () => {
       <SortableTree<CustomTreeItem>
         isCollapsible
         showDropIndicator
+        autoExpandOnHoverDelay={600}
         items={treeItems}
         setItems={setTreeItems}
         renderItem={MyCustomTreeItem}


### PR DESCRIPTION
## Why

Dragging into deep trees is harder than it needs to be when a target parent is collapsed.

Right now, if a user starts dragging an item toward a collapsed branch, they cannot keep moving deeper into that branch without first dropping the item or manually expanding nodes ahead of time. That interrupts the drag-and-drop flow and makes the interaction feel more rigid than it should.

This change adds an optional mechanism to expand collapsed parents while the user is hovering in a nesting position, so they can continue their journey to the final drop target without breaking the interaction.

## What changed

- added a new optional `autoExpandOnHoverDelay` prop to `SortableTree`
- when this prop is provided, collapsed parents can expand automatically after the configured hover delay while dragging into them
- kept the behavior opt-in, so consumers control whether to enable it and how long the delay should be
- updated the demo and documentation to show how to use the new prop
- added test coverage for the hover-to-expand drag flow

## Usage

Pass a delay in milliseconds to enable the behavior:

```tsx
<SortableTree autoExpandOnHoverDelay={600} {...props} />
